### PR TITLE
Replace status_t with mems_status_t

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=LSM303AGR
-version=1.0.0
+name=STM32duino LSM303AGR
+version=1.0.1
 author=AST
 maintainer=stm32duino
 sentence=3D accelerometer and 3D magnetometer.

--- a/src/LSM303AGR_ACC_driver.c
+++ b/src/LSM303AGR_ACC_driver.c
@@ -60,7 +60,7 @@ extern uint8_t LSM303AGR_ACC_IO_Read(void *handle, uint8_t ReadAddr, uint8_t *pB
 * Output			: Data REad
 * Return			: None
 *******************************************************************************/
-status_t LSM303AGR_ACC_ReadReg(void *handle, u8_t Reg, u8_t* Data) 
+mems_status_t LSM303AGR_ACC_ReadReg(void *handle, u8_t Reg, u8_t* Data) 
 {
   
   if (LSM303AGR_ACC_IO_Read(handle, Reg, Data, 1))
@@ -81,7 +81,7 @@ status_t LSM303AGR_ACC_ReadReg(void *handle, u8_t Reg, u8_t* Data)
 * Output			: None
 * Return			: None
 *******************************************************************************/
-status_t LSM303AGR_ACC_WriteReg(void *handle, u8_t Reg, u8_t Data) 
+mems_status_t LSM303AGR_ACC_WriteReg(void *handle, u8_t Reg, u8_t Data) 
 {
     
   if (LSM303AGR_ACC_IO_Write(handle, Reg, &Data, 1))
@@ -134,7 +134,7 @@ void LSM303AGR_ACC_SwapHighLowByte(u8_t *bufferToSwap, u8_t numberOfByte, u8_t d
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_x_data_avail(void *handle, LSM303AGR_ACC_1DA_t *value)
+mems_status_t LSM303AGR_ACC_R_x_data_avail(void *handle, LSM303AGR_ACC_1DA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -151,7 +151,7 @@ status_t LSM303AGR_ACC_R_x_data_avail(void *handle, LSM303AGR_ACC_1DA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_y_data_avail(void *handle, LSM303AGR_ACC_2DA__t *value)
+mems_status_t LSM303AGR_ACC_R_y_data_avail(void *handle, LSM303AGR_ACC_2DA__t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -168,7 +168,7 @@ status_t LSM303AGR_ACC_R_y_data_avail(void *handle, LSM303AGR_ACC_2DA__t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_z_data_avail(void *handle, LSM303AGR_ACC_3DA__t *value)
+mems_status_t LSM303AGR_ACC_R_z_data_avail(void *handle, LSM303AGR_ACC_3DA__t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -185,7 +185,7 @@ status_t LSM303AGR_ACC_R_z_data_avail(void *handle, LSM303AGR_ACC_3DA__t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_xyz_data_avail(void *handle, LSM303AGR_ACC_321DA__t *value)
+mems_status_t LSM303AGR_ACC_R_xyz_data_avail(void *handle, LSM303AGR_ACC_321DA__t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -202,7 +202,7 @@ status_t LSM303AGR_ACC_R_xyz_data_avail(void *handle, LSM303AGR_ACC_321DA__t *va
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_DataXOverrun(void *handle, LSM303AGR_ACC_1OR__t *value)
+mems_status_t LSM303AGR_ACC_R_DataXOverrun(void *handle, LSM303AGR_ACC_1OR__t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -219,7 +219,7 @@ status_t LSM303AGR_ACC_R_DataXOverrun(void *handle, LSM303AGR_ACC_1OR__t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_DataYOverrun(void *handle, LSM303AGR_ACC_2OR__t *value)
+mems_status_t LSM303AGR_ACC_R_DataYOverrun(void *handle, LSM303AGR_ACC_2OR__t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -236,7 +236,7 @@ status_t LSM303AGR_ACC_R_DataYOverrun(void *handle, LSM303AGR_ACC_2OR__t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_DataZOverrun(void *handle, LSM303AGR_ACC_3OR__t *value)
+mems_status_t LSM303AGR_ACC_R_DataZOverrun(void *handle, LSM303AGR_ACC_3OR__t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -253,7 +253,7 @@ status_t LSM303AGR_ACC_R_DataZOverrun(void *handle, LSM303AGR_ACC_3OR__t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_DataXYZOverrun(void *handle, LSM303AGR_ACC_321OR__t *value)
+mems_status_t LSM303AGR_ACC_R_DataXYZOverrun(void *handle, LSM303AGR_ACC_321OR__t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG_AUX, (u8_t *)value) )
     return MEMS_ERROR;
@@ -270,7 +270,7 @@ status_t LSM303AGR_ACC_R_DataXYZOverrun(void *handle, LSM303AGR_ACC_321OR__t *va
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_int_counter(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_int_counter(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT_COUNTER_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -288,7 +288,7 @@ status_t LSM303AGR_ACC_R_int_counter(void *handle, u8_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_WHO_AM_I(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_WHO_AM_I(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_WHO_AM_I_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -305,7 +305,7 @@ status_t LSM303AGR_ACC_R_WHO_AM_I(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t newValue)
 {
   u8_t value;
 
@@ -329,7 +329,7 @@ status_t  LSM303AGR_ACC_W_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t new
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t *value)
+mems_status_t LSM303AGR_ACC_R_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_TEMP_CFG_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -345,7 +345,7 @@ status_t LSM303AGR_ACC_R_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t *val
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t newValue)
 {
   u8_t value;
 
@@ -369,7 +369,7 @@ status_t  LSM303AGR_ACC_W_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t *value)
+mems_status_t LSM303AGR_ACC_R_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_TEMP_CFG_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -385,7 +385,7 @@ status_t LSM303AGR_ACC_R_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_XEN(void *handle, LSM303AGR_ACC_XEN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_XEN(void *handle, LSM303AGR_ACC_XEN_t newValue)
 {
   u8_t value;
 
@@ -409,7 +409,7 @@ status_t  LSM303AGR_ACC_W_XEN(void *handle, LSM303AGR_ACC_XEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_XEN(void *handle, LSM303AGR_ACC_XEN_t *value)
+mems_status_t LSM303AGR_ACC_R_XEN(void *handle, LSM303AGR_ACC_XEN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG1, (u8_t *)value) )
     return MEMS_ERROR;
@@ -425,7 +425,7 @@ status_t LSM303AGR_ACC_R_XEN(void *handle, LSM303AGR_ACC_XEN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_YEN(void *handle, LSM303AGR_ACC_YEN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_YEN(void *handle, LSM303AGR_ACC_YEN_t newValue)
 {
   u8_t value;
 
@@ -449,7 +449,7 @@ status_t  LSM303AGR_ACC_W_YEN(void *handle, LSM303AGR_ACC_YEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_YEN(void *handle, LSM303AGR_ACC_YEN_t *value)
+mems_status_t LSM303AGR_ACC_R_YEN(void *handle, LSM303AGR_ACC_YEN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG1, (u8_t *)value) )
     return MEMS_ERROR;
@@ -465,7 +465,7 @@ status_t LSM303AGR_ACC_R_YEN(void *handle, LSM303AGR_ACC_YEN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ZEN(void *handle, LSM303AGR_ACC_ZEN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ZEN(void *handle, LSM303AGR_ACC_ZEN_t newValue)
 {
   u8_t value;
 
@@ -489,7 +489,7 @@ status_t  LSM303AGR_ACC_W_ZEN(void *handle, LSM303AGR_ACC_ZEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ZEN(void *handle, LSM303AGR_ACC_ZEN_t *value)
+mems_status_t LSM303AGR_ACC_R_ZEN(void *handle, LSM303AGR_ACC_ZEN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG1, (u8_t *)value) )
     return MEMS_ERROR;
@@ -505,7 +505,7 @@ status_t LSM303AGR_ACC_R_ZEN(void *handle, LSM303AGR_ACC_ZEN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t newValue)
 {
   u8_t value;
 
@@ -529,7 +529,7 @@ status_t  LSM303AGR_ACC_W_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t *value)
+mems_status_t LSM303AGR_ACC_R_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG1, (u8_t *)value) )
     return MEMS_ERROR;
@@ -545,7 +545,7 @@ status_t LSM303AGR_ACC_R_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ODR(void *handle, LSM303AGR_ACC_ODR_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ODR(void *handle, LSM303AGR_ACC_ODR_t newValue)
 {
   u8_t value;
 
@@ -569,7 +569,7 @@ status_t  LSM303AGR_ACC_W_ODR(void *handle, LSM303AGR_ACC_ODR_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ODR(void *handle, LSM303AGR_ACC_ODR_t *value)
+mems_status_t LSM303AGR_ACC_R_ODR(void *handle, LSM303AGR_ACC_ODR_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG1, (u8_t *)value) )
     return MEMS_ERROR;
@@ -585,7 +585,7 @@ status_t LSM303AGR_ACC_R_ODR(void *handle, LSM303AGR_ACC_ODR_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t newValue)
+mems_status_t  LSM303AGR_ACC_W_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t newValue)
 {
   u8_t value;
 
@@ -609,7 +609,7 @@ status_t  LSM303AGR_ACC_W_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t ne
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t *value)
+mems_status_t LSM303AGR_ACC_R_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -625,7 +625,7 @@ status_t LSM303AGR_ACC_R_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t newValue)
+mems_status_t  LSM303AGR_ACC_W_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t newValue)
 {
   u8_t value;
 
@@ -649,7 +649,7 @@ status_t  LSM303AGR_ACC_W_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t ne
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t *value)
+mems_status_t LSM303AGR_ACC_R_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -665,7 +665,7 @@ status_t LSM303AGR_ACC_R_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t newValue)
+mems_status_t  LSM303AGR_ACC_W_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t newValue)
 {
   u8_t value;
 
@@ -689,7 +689,7 @@ status_t  LSM303AGR_ACC_W_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t new
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t *value)
+mems_status_t LSM303AGR_ACC_R_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -705,7 +705,7 @@ status_t LSM303AGR_ACC_R_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t *val
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t newValue)
 {
   u8_t value;
 
@@ -729,7 +729,7 @@ status_t  LSM303AGR_ACC_W_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t newValue
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t *value)
+mems_status_t LSM303AGR_ACC_R_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -745,7 +745,7 @@ status_t LSM303AGR_ACC_R_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t newValue)
+mems_status_t  LSM303AGR_ACC_W_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t newValue)
 {
   u8_t value;
 
@@ -769,7 +769,7 @@ status_t  LSM303AGR_ACC_W_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t new
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t *value)
+mems_status_t LSM303AGR_ACC_R_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -785,7 +785,7 @@ status_t LSM303AGR_ACC_R_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t *val
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t newValue)
+mems_status_t  LSM303AGR_ACC_W_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t newValue)
 {
   u8_t value;
 
@@ -809,7 +809,7 @@ status_t  LSM303AGR_ACC_W_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t *value)
+mems_status_t LSM303AGR_ACC_R_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -825,7 +825,7 @@ status_t LSM303AGR_ACC_R_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t newValue)
 {
   u8_t value;
 
@@ -849,7 +849,7 @@ status_t  LSM303AGR_ACC_W_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OV
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG3, (u8_t *)value) )
     return MEMS_ERROR;
@@ -865,7 +865,7 @@ status_t LSM303AGR_ACC_R_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVE
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t newValue)
 {
   u8_t value;
 
@@ -889,7 +889,7 @@ status_t  LSM303AGR_ACC_W_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG3, (u8_t *)value) )
     return MEMS_ERROR;
@@ -905,7 +905,7 @@ status_t LSM303AGR_ACC_R_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_W
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t newValue)
 {
   u8_t value;
 
@@ -929,7 +929,7 @@ status_t  LSM303AGR_ACC_W_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG3, (u8_t *)value) )
     return MEMS_ERROR;
@@ -945,7 +945,7 @@ status_t LSM303AGR_ACC_R_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t newValue)
 {
   u8_t value;
 
@@ -969,7 +969,7 @@ status_t  LSM303AGR_ACC_W_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG3, (u8_t *)value) )
     return MEMS_ERROR;
@@ -985,7 +985,7 @@ status_t LSM303AGR_ACC_R_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t newValue)
 {
   u8_t value;
 
@@ -1009,7 +1009,7 @@ status_t  LSM303AGR_ACC_W_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG3, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1025,7 +1025,7 @@ status_t LSM303AGR_ACC_R_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t newValue)
 {
   u8_t value;
 
@@ -1049,7 +1049,7 @@ status_t  LSM303AGR_ACC_W_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG3, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1065,7 +1065,7 @@ status_t LSM303AGR_ACC_R_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t newValue)
 {
   u8_t value;
 
@@ -1089,7 +1089,7 @@ status_t  LSM303AGR_ACC_W_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLIC
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG3, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1105,7 +1105,7 @@ status_t LSM303AGR_ACC_R_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t newValue)
+mems_status_t  LSM303AGR_ACC_W_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t newValue)
 {
   u8_t value;
 
@@ -1129,7 +1129,7 @@ status_t  LSM303AGR_ACC_W_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t *value)
+mems_status_t LSM303AGR_ACC_R_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG4, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1145,7 +1145,7 @@ status_t LSM303AGR_ACC_R_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_SelfTest(void *handle, LSM303AGR_ACC_ST_t newValue)
+mems_status_t  LSM303AGR_ACC_W_SelfTest(void *handle, LSM303AGR_ACC_ST_t newValue)
 {
   u8_t value;
 
@@ -1169,7 +1169,7 @@ status_t  LSM303AGR_ACC_W_SelfTest(void *handle, LSM303AGR_ACC_ST_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_SelfTest(void *handle, LSM303AGR_ACC_ST_t *value)
+mems_status_t LSM303AGR_ACC_R_SelfTest(void *handle, LSM303AGR_ACC_ST_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG4, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1185,7 +1185,7 @@ status_t LSM303AGR_ACC_R_SelfTest(void *handle, LSM303AGR_ACC_ST_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_HiRes(void *handle, LSM303AGR_ACC_HR_t newValue)
+mems_status_t  LSM303AGR_ACC_W_HiRes(void *handle, LSM303AGR_ACC_HR_t newValue)
 {
   u8_t value;
 
@@ -1209,7 +1209,7 @@ status_t  LSM303AGR_ACC_W_HiRes(void *handle, LSM303AGR_ACC_HR_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_HiRes(void *handle, LSM303AGR_ACC_HR_t *value)
+mems_status_t LSM303AGR_ACC_R_HiRes(void *handle, LSM303AGR_ACC_HR_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG4, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1225,7 +1225,7 @@ status_t LSM303AGR_ACC_R_HiRes(void *handle, LSM303AGR_ACC_HR_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FullScale(void *handle, LSM303AGR_ACC_FS_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FullScale(void *handle, LSM303AGR_ACC_FS_t newValue)
 {
   u8_t value;
 
@@ -1249,7 +1249,7 @@ status_t  LSM303AGR_ACC_W_FullScale(void *handle, LSM303AGR_ACC_FS_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FullScale(void *handle, LSM303AGR_ACC_FS_t *value)
+mems_status_t LSM303AGR_ACC_R_FullScale(void *handle, LSM303AGR_ACC_FS_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG4, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1265,7 +1265,7 @@ status_t LSM303AGR_ACC_R_FullScale(void *handle, LSM303AGR_ACC_FS_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t newValue)
 {
   u8_t value;
 
@@ -1289,7 +1289,7 @@ status_t  LSM303AGR_ACC_W_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t newV
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t *value)
+mems_status_t LSM303AGR_ACC_R_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG4, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1305,7 +1305,7 @@ status_t LSM303AGR_ACC_R_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t newValue)
+mems_status_t  LSM303AGR_ACC_W_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t newValue)
 {
   u8_t value;
 
@@ -1329,7 +1329,7 @@ status_t  LSM303AGR_ACC_W_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t newV
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t *value)
+mems_status_t LSM303AGR_ACC_R_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG4, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1345,7 +1345,7 @@ status_t LSM303AGR_ACC_R_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t newValue)
+mems_status_t  LSM303AGR_ACC_W_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t newValue)
 {
   u8_t value;
 
@@ -1369,7 +1369,7 @@ status_t  LSM303AGR_ACC_W_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t newV
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t *value)
+mems_status_t LSM303AGR_ACC_R_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG5, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1385,7 +1385,7 @@ status_t LSM303AGR_ACC_R_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t newValue)
+mems_status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t newValue)
 {
   u8_t value;
 
@@ -1409,7 +1409,7 @@ status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t *value)
+mems_status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG5, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1426,7 +1426,7 @@ status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t newValue)
+mems_status_t  LSM303AGR_ACC_W_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t newValue)
 {
   u8_t value;
 
@@ -1450,7 +1450,7 @@ status_t  LSM303AGR_ACC_W_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t newV
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t *value)
+mems_status_t LSM303AGR_ACC_R_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG5, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1466,7 +1466,7 @@ status_t LSM303AGR_ACC_R_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t newValue)
+mems_status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t newValue)
 {
   u8_t value;
 
@@ -1490,7 +1490,7 @@ status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t *value)
+mems_status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG5, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1507,7 +1507,7 @@ status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t newValue)
 {
   u8_t value;
 
@@ -1531,7 +1531,7 @@ status_t  LSM303AGR_ACC_W_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t newValue
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t *value)
+mems_status_t LSM303AGR_ACC_R_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG5, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1547,7 +1547,7 @@ status_t LSM303AGR_ACC_R_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t newValue)
+mems_status_t  LSM303AGR_ACC_W_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t newValue)
 {
   u8_t value;
 
@@ -1571,7 +1571,7 @@ status_t  LSM303AGR_ACC_W_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t newVal
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t *value)
+mems_status_t LSM303AGR_ACC_R_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG5, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1587,7 +1587,7 @@ status_t LSM303AGR_ACC_R_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t newValue)
 {
   u8_t value;
 
@@ -1611,7 +1611,7 @@ status_t  LSM303AGR_ACC_W_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t newV
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t *value)
+mems_status_t LSM303AGR_ACC_R_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG6, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1628,7 +1628,7 @@ status_t LSM303AGR_ACC_R_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t newValue)
+mems_status_t  LSM303AGR_ACC_W_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t newValue)
 {
   u8_t value;
 
@@ -1652,7 +1652,7 @@ status_t  LSM303AGR_ACC_W_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t *value)
+mems_status_t LSM303AGR_ACC_R_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG6, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1669,7 +1669,7 @@ status_t LSM303AGR_ACC_R_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t newValue)
 {
   u8_t value;
 
@@ -1693,7 +1693,7 @@ status_t  LSM303AGR_ACC_W_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t new
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t *value)
+mems_status_t LSM303AGR_ACC_R_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG6, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1709,7 +1709,7 @@ status_t LSM303AGR_ACC_R_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t *val
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t newValue)
+mems_status_t  LSM303AGR_ACC_W_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t newValue)
 {
   u8_t value;
 
@@ -1733,7 +1733,7 @@ status_t  LSM303AGR_ACC_W_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t newVa
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t *value)
+mems_status_t LSM303AGR_ACC_R_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG6, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1749,7 +1749,7 @@ status_t LSM303AGR_ACC_R_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t *value
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t newValue)
+mems_status_t  LSM303AGR_ACC_W_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t newValue)
 {
   u8_t value;
 
@@ -1773,7 +1773,7 @@ status_t  LSM303AGR_ACC_W_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t newVa
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t *value)
+mems_status_t LSM303AGR_ACC_R_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG6, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1789,7 +1789,7 @@ status_t LSM303AGR_ACC_R_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t *value
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t newValue)
 {
   u8_t value;
 
@@ -1813,7 +1813,7 @@ status_t  LSM303AGR_ACC_W_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t *value)
+mems_status_t LSM303AGR_ACC_R_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CTRL_REG6, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1829,7 +1829,7 @@ status_t LSM303AGR_ACC_R_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ReferenceVal(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ReferenceVal(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -1856,7 +1856,7 @@ status_t  LSM303AGR_ACC_W_ReferenceVal(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ReferenceVal(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_ReferenceVal(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_REFERENCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1874,7 +1874,7 @@ status_t LSM303AGR_ACC_R_ReferenceVal(void *handle, u8_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_XDataAvail(void *handle, LSM303AGR_ACC_XDA_t *value)
+mems_status_t LSM303AGR_ACC_R_XDataAvail(void *handle, LSM303AGR_ACC_XDA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1891,7 +1891,7 @@ status_t LSM303AGR_ACC_R_XDataAvail(void *handle, LSM303AGR_ACC_XDA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_YDataAvail(void *handle, LSM303AGR_ACC_YDA_t *value)
+mems_status_t LSM303AGR_ACC_R_YDataAvail(void *handle, LSM303AGR_ACC_YDA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1908,7 +1908,7 @@ status_t LSM303AGR_ACC_R_YDataAvail(void *handle, LSM303AGR_ACC_YDA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ZDataAvail(void *handle, LSM303AGR_ACC_ZDA_t *value)
+mems_status_t LSM303AGR_ACC_R_ZDataAvail(void *handle, LSM303AGR_ACC_ZDA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1925,7 +1925,7 @@ status_t LSM303AGR_ACC_R_ZDataAvail(void *handle, LSM303AGR_ACC_ZDA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_XYZDataAvail(void *handle, LSM303AGR_ACC_ZYXDA_t *value)
+mems_status_t LSM303AGR_ACC_R_XYZDataAvail(void *handle, LSM303AGR_ACC_ZYXDA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1942,7 +1942,7 @@ status_t LSM303AGR_ACC_R_XYZDataAvail(void *handle, LSM303AGR_ACC_ZYXDA_t *value
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_XDataOverrun(void *handle, LSM303AGR_ACC_XOR_t *value)
+mems_status_t LSM303AGR_ACC_R_XDataOverrun(void *handle, LSM303AGR_ACC_XOR_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1959,7 +1959,7 @@ status_t LSM303AGR_ACC_R_XDataOverrun(void *handle, LSM303AGR_ACC_XOR_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_YDataOverrun(void *handle, LSM303AGR_ACC_YOR_t *value)
+mems_status_t LSM303AGR_ACC_R_YDataOverrun(void *handle, LSM303AGR_ACC_YOR_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1976,7 +1976,7 @@ status_t LSM303AGR_ACC_R_YDataOverrun(void *handle, LSM303AGR_ACC_YOR_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ZDataOverrun(void *handle, LSM303AGR_ACC_ZOR_t *value)
+mems_status_t LSM303AGR_ACC_R_ZDataOverrun(void *handle, LSM303AGR_ACC_ZOR_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1993,7 +1993,7 @@ status_t LSM303AGR_ACC_R_ZDataOverrun(void *handle, LSM303AGR_ACC_ZOR_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_XYZDataOverrun(void *handle, LSM303AGR_ACC_ZYXOR_t *value)
+mems_status_t LSM303AGR_ACC_R_XYZDataOverrun(void *handle, LSM303AGR_ACC_ZYXOR_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_STATUS_REG2, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2009,7 +2009,7 @@ status_t LSM303AGR_ACC_R_XYZDataOverrun(void *handle, LSM303AGR_ACC_ZYXOR_t *val
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FifoThreshold(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FifoThreshold(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -2036,7 +2036,7 @@ status_t  LSM303AGR_ACC_W_FifoThreshold(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FifoThreshold(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_FifoThreshold(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_FIFO_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2053,7 +2053,7 @@ status_t LSM303AGR_ACC_R_FifoThreshold(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_TriggerSel(void *handle, LSM303AGR_ACC_TR_t newValue)
+mems_status_t  LSM303AGR_ACC_W_TriggerSel(void *handle, LSM303AGR_ACC_TR_t newValue)
 {
   u8_t value;
 
@@ -2077,7 +2077,7 @@ status_t  LSM303AGR_ACC_W_TriggerSel(void *handle, LSM303AGR_ACC_TR_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_TriggerSel(void *handle, LSM303AGR_ACC_TR_t *value)
+mems_status_t LSM303AGR_ACC_R_TriggerSel(void *handle, LSM303AGR_ACC_TR_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_FIFO_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2093,7 +2093,7 @@ status_t LSM303AGR_ACC_R_TriggerSel(void *handle, LSM303AGR_ACC_TR_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_FifoMode(void *handle, LSM303AGR_ACC_FM_t newValue)
+mems_status_t  LSM303AGR_ACC_W_FifoMode(void *handle, LSM303AGR_ACC_FM_t newValue)
 {
   u8_t value;
 
@@ -2117,7 +2117,7 @@ status_t  LSM303AGR_ACC_W_FifoMode(void *handle, LSM303AGR_ACC_FM_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FifoMode(void *handle, LSM303AGR_ACC_FM_t *value)
+mems_status_t LSM303AGR_ACC_R_FifoMode(void *handle, LSM303AGR_ACC_FM_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_FIFO_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2134,7 +2134,7 @@ status_t LSM303AGR_ACC_R_FifoMode(void *handle, LSM303AGR_ACC_FM_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FifoSamplesAvail(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_FifoSamplesAvail(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_FIFO_SRC_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2152,7 +2152,7 @@ status_t LSM303AGR_ACC_R_FifoSamplesAvail(void *handle, u8_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FifoEmpty(void *handle, LSM303AGR_ACC_EMPTY_t *value)
+mems_status_t LSM303AGR_ACC_R_FifoEmpty(void *handle, LSM303AGR_ACC_EMPTY_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_FIFO_SRC_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2169,7 +2169,7 @@ status_t LSM303AGR_ACC_R_FifoEmpty(void *handle, LSM303AGR_ACC_EMPTY_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_FifoOverrun(void *handle, LSM303AGR_ACC_OVRN_FIFO_t *value)
+mems_status_t LSM303AGR_ACC_R_FifoOverrun(void *handle, LSM303AGR_ACC_OVRN_FIFO_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_FIFO_SRC_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2186,7 +2186,7 @@ status_t LSM303AGR_ACC_R_FifoOverrun(void *handle, LSM303AGR_ACC_OVRN_FIFO_t *va
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_WatermarkLevel(void *handle, LSM303AGR_ACC_WTM_t *value)
+mems_status_t LSM303AGR_ACC_R_WatermarkLevel(void *handle, LSM303AGR_ACC_WTM_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_FIFO_SRC_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2202,7 +2202,7 @@ status_t LSM303AGR_ACC_R_WatermarkLevel(void *handle, LSM303AGR_ACC_WTM_t *value
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue)
 {
   u8_t value;
 
@@ -2226,7 +2226,7 @@ status_t  LSM303AGR_ACC_W_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2242,7 +2242,7 @@ status_t LSM303AGR_ACC_R_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue)
 {
   u8_t value;
 
@@ -2266,7 +2266,7 @@ status_t  LSM303AGR_ACC_W_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2282,7 +2282,7 @@ status_t LSM303AGR_ACC_R_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue)
 {
   u8_t value;
 
@@ -2306,7 +2306,7 @@ status_t  LSM303AGR_ACC_W_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2322,7 +2322,7 @@ status_t LSM303AGR_ACC_R_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue)
 {
   u8_t value;
 
@@ -2346,7 +2346,7 @@ status_t  LSM303AGR_ACC_W_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2362,7 +2362,7 @@ status_t LSM303AGR_ACC_R_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue)
 {
   u8_t value;
 
@@ -2386,7 +2386,7 @@ status_t  LSM303AGR_ACC_W_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2402,7 +2402,7 @@ status_t LSM303AGR_ACC_R_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue)
 {
   u8_t value;
 
@@ -2426,7 +2426,7 @@ status_t  LSM303AGR_ACC_W_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2442,7 +2442,7 @@ status_t LSM303AGR_ACC_R_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1_6D(void *handle, LSM303AGR_ACC_6D_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1_6D(void *handle, LSM303AGR_ACC_6D_t newValue)
 {
   u8_t value;
 
@@ -2466,7 +2466,7 @@ status_t  LSM303AGR_ACC_W_Int1_6D(void *handle, LSM303AGR_ACC_6D_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_6D(void *handle, LSM303AGR_ACC_6D_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_6D(void *handle, LSM303AGR_ACC_6D_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2482,7 +2482,7 @@ status_t LSM303AGR_ACC_R_Int1_6D(void *handle, LSM303AGR_ACC_6D_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue)
 {
   u8_t value;
 
@@ -2506,7 +2506,7 @@ status_t  LSM303AGR_ACC_W_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2522,7 +2522,7 @@ status_t LSM303AGR_ACC_R_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue)
 {
   u8_t value;
 
@@ -2546,7 +2546,7 @@ status_t  LSM303AGR_ACC_W_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2562,7 +2562,7 @@ status_t LSM303AGR_ACC_R_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue)
 {
   u8_t value;
 
@@ -2586,7 +2586,7 @@ status_t  LSM303AGR_ACC_W_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2602,7 +2602,7 @@ status_t LSM303AGR_ACC_R_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue)
 {
   u8_t value;
 
@@ -2626,7 +2626,7 @@ status_t  LSM303AGR_ACC_W_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2642,7 +2642,7 @@ status_t LSM303AGR_ACC_R_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue)
 {
   u8_t value;
 
@@ -2666,7 +2666,7 @@ status_t  LSM303AGR_ACC_W_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2682,7 +2682,7 @@ status_t LSM303AGR_ACC_R_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue)
 {
   u8_t value;
 
@@ -2706,7 +2706,7 @@ status_t  LSM303AGR_ACC_W_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2722,7 +2722,7 @@ status_t LSM303AGR_ACC_R_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue)
 {
   u8_t value;
 
@@ -2746,7 +2746,7 @@ status_t  LSM303AGR_ACC_W_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2762,7 +2762,7 @@ status_t LSM303AGR_ACC_R_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2_6D(void *handle, LSM303AGR_ACC_6D_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2_6D(void *handle, LSM303AGR_ACC_6D_t newValue)
 {
   u8_t value;
 
@@ -2786,7 +2786,7 @@ status_t  LSM303AGR_ACC_W_Int2_6D(void *handle, LSM303AGR_ACC_6D_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_6D(void *handle, LSM303AGR_ACC_6D_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_6D(void *handle, LSM303AGR_ACC_6D_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2802,7 +2802,7 @@ status_t LSM303AGR_ACC_R_Int2_6D(void *handle, LSM303AGR_ACC_6D_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue)
 {
   u8_t value;
 
@@ -2826,7 +2826,7 @@ status_t  LSM303AGR_ACC_W_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2844,7 +2844,7 @@ status_t LSM303AGR_ACC_R_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_Xlo(void *handle, LSM303AGR_ACC_XL_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_Xlo(void *handle, LSM303AGR_ACC_XL_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2861,7 +2861,7 @@ status_t LSM303AGR_ACC_R_Int1_Xlo(void *handle, LSM303AGR_ACC_XL_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_XHi(void *handle, LSM303AGR_ACC_XH_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_XHi(void *handle, LSM303AGR_ACC_XH_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2878,7 +2878,7 @@ status_t LSM303AGR_ACC_R_Int1_XHi(void *handle, LSM303AGR_ACC_XH_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_YLo(void *handle, LSM303AGR_ACC_YL_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_YLo(void *handle, LSM303AGR_ACC_YL_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2895,7 +2895,7 @@ status_t LSM303AGR_ACC_R_Int1_YLo(void *handle, LSM303AGR_ACC_YL_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_YHi(void *handle, LSM303AGR_ACC_YH_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_YHi(void *handle, LSM303AGR_ACC_YH_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2912,7 +2912,7 @@ status_t LSM303AGR_ACC_R_Int1_YHi(void *handle, LSM303AGR_ACC_YH_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2929,7 +2929,7 @@ status_t LSM303AGR_ACC_R_Int1_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2946,7 +2946,7 @@ status_t LSM303AGR_ACC_R_Int1_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_IA(void *handle, LSM303AGR_ACC_IA_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_IA(void *handle, LSM303AGR_ACC_IA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2964,7 +2964,7 @@ status_t LSM303AGR_ACC_R_Int1_IA(void *handle, LSM303AGR_ACC_IA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_Xlo(void *handle, LSM303AGR_ACC_XL_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_Xlo(void *handle, LSM303AGR_ACC_XL_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2981,7 +2981,7 @@ status_t LSM303AGR_ACC_R_Int2_Xlo(void *handle, LSM303AGR_ACC_XL_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_XHi(void *handle, LSM303AGR_ACC_XH_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_XHi(void *handle, LSM303AGR_ACC_XH_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -2998,7 +2998,7 @@ status_t LSM303AGR_ACC_R_Int2_XHi(void *handle, LSM303AGR_ACC_XH_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_YLo(void *handle, LSM303AGR_ACC_YL_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_YLo(void *handle, LSM303AGR_ACC_YL_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3015,7 +3015,7 @@ status_t LSM303AGR_ACC_R_Int2_YLo(void *handle, LSM303AGR_ACC_YL_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_YHi(void *handle, LSM303AGR_ACC_YH_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_YHi(void *handle, LSM303AGR_ACC_YH_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3032,7 +3032,7 @@ status_t LSM303AGR_ACC_R_Int2_YHi(void *handle, LSM303AGR_ACC_YH_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3049,7 +3049,7 @@ status_t LSM303AGR_ACC_R_Int2_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3066,7 +3066,7 @@ status_t LSM303AGR_ACC_R_Int2_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_IA(void *handle, LSM303AGR_ACC_IA_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_IA(void *handle, LSM303AGR_ACC_IA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_SOURCE, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3083,7 +3083,7 @@ status_t LSM303AGR_ACC_R_Int2_IA(void *handle, LSM303AGR_ACC_IA_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1_Threshold(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1_Threshold(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3110,7 +3110,7 @@ status_t  LSM303AGR_ACC_W_Int1_Threshold(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_Threshold(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_Threshold(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_THS, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3128,7 +3128,7 @@ status_t LSM303AGR_ACC_R_Int1_Threshold(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2_Threshold(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2_Threshold(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3155,7 +3155,7 @@ status_t  LSM303AGR_ACC_W_Int2_Threshold(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_Threshold(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_Threshold(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_THS, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3173,7 +3173,7 @@ status_t LSM303AGR_ACC_R_Int2_Threshold(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int1_Duration(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int1_Duration(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3200,7 +3200,7 @@ status_t  LSM303AGR_ACC_W_Int1_Duration(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int1_Duration(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_Int1_Duration(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT1_DURATION, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3218,7 +3218,7 @@ status_t LSM303AGR_ACC_R_Int1_Duration(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_Int2_Duration(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_Int2_Duration(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3245,7 +3245,7 @@ status_t  LSM303AGR_ACC_W_Int2_Duration(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_Int2_Duration(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_Int2_Duration(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_INT2_DURATION, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3263,7 +3263,7 @@ status_t LSM303AGR_ACC_R_Int2_Duration(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_XSingle(void *handle, LSM303AGR_ACC_XS_t newValue)
+mems_status_t  LSM303AGR_ACC_W_XSingle(void *handle, LSM303AGR_ACC_XS_t newValue)
 {
   u8_t value;
 
@@ -3287,7 +3287,7 @@ status_t  LSM303AGR_ACC_W_XSingle(void *handle, LSM303AGR_ACC_XS_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_XSingle(void *handle, LSM303AGR_ACC_XS_t *value)
+mems_status_t LSM303AGR_ACC_R_XSingle(void *handle, LSM303AGR_ACC_XS_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3303,7 +3303,7 @@ status_t LSM303AGR_ACC_R_XSingle(void *handle, LSM303AGR_ACC_XS_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_XDouble(void *handle, LSM303AGR_ACC_XD_t newValue)
+mems_status_t  LSM303AGR_ACC_W_XDouble(void *handle, LSM303AGR_ACC_XD_t newValue)
 {
   u8_t value;
 
@@ -3327,7 +3327,7 @@ status_t  LSM303AGR_ACC_W_XDouble(void *handle, LSM303AGR_ACC_XD_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_XDouble(void *handle, LSM303AGR_ACC_XD_t *value)
+mems_status_t LSM303AGR_ACC_R_XDouble(void *handle, LSM303AGR_ACC_XD_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3343,7 +3343,7 @@ status_t LSM303AGR_ACC_R_XDouble(void *handle, LSM303AGR_ACC_XD_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_YSingle(void *handle, LSM303AGR_ACC_YS_t newValue)
+mems_status_t  LSM303AGR_ACC_W_YSingle(void *handle, LSM303AGR_ACC_YS_t newValue)
 {
   u8_t value;
 
@@ -3367,7 +3367,7 @@ status_t  LSM303AGR_ACC_W_YSingle(void *handle, LSM303AGR_ACC_YS_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_YSingle(void *handle, LSM303AGR_ACC_YS_t *value)
+mems_status_t LSM303AGR_ACC_R_YSingle(void *handle, LSM303AGR_ACC_YS_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3383,7 +3383,7 @@ status_t LSM303AGR_ACC_R_YSingle(void *handle, LSM303AGR_ACC_YS_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_YDouble(void *handle, LSM303AGR_ACC_YD_t newValue)
+mems_status_t  LSM303AGR_ACC_W_YDouble(void *handle, LSM303AGR_ACC_YD_t newValue)
 {
   u8_t value;
 
@@ -3407,7 +3407,7 @@ status_t  LSM303AGR_ACC_W_YDouble(void *handle, LSM303AGR_ACC_YD_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_YDouble(void *handle, LSM303AGR_ACC_YD_t *value)
+mems_status_t LSM303AGR_ACC_R_YDouble(void *handle, LSM303AGR_ACC_YD_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3423,7 +3423,7 @@ status_t LSM303AGR_ACC_R_YDouble(void *handle, LSM303AGR_ACC_YD_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ZSingle(void *handle, LSM303AGR_ACC_ZS_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ZSingle(void *handle, LSM303AGR_ACC_ZS_t newValue)
 {
   u8_t value;
 
@@ -3447,7 +3447,7 @@ status_t  LSM303AGR_ACC_W_ZSingle(void *handle, LSM303AGR_ACC_ZS_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ZSingle(void *handle, LSM303AGR_ACC_ZS_t *value)
+mems_status_t LSM303AGR_ACC_R_ZSingle(void *handle, LSM303AGR_ACC_ZS_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3463,7 +3463,7 @@ status_t LSM303AGR_ACC_R_ZSingle(void *handle, LSM303AGR_ACC_ZS_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ZDouble(void *handle, LSM303AGR_ACC_ZD_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ZDouble(void *handle, LSM303AGR_ACC_ZD_t newValue)
 {
   u8_t value;
 
@@ -3487,7 +3487,7 @@ status_t  LSM303AGR_ACC_W_ZDouble(void *handle, LSM303AGR_ACC_ZD_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ZDouble(void *handle, LSM303AGR_ACC_ZD_t *value)
+mems_status_t LSM303AGR_ACC_R_ZDouble(void *handle, LSM303AGR_ACC_ZD_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_CFG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3504,7 +3504,7 @@ status_t LSM303AGR_ACC_R_ZDouble(void *handle, LSM303AGR_ACC_ZD_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickX(void *handle, LSM303AGR_ACC_X_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickX(void *handle, LSM303AGR_ACC_X_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_SRC, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3521,7 +3521,7 @@ status_t LSM303AGR_ACC_R_ClickX(void *handle, LSM303AGR_ACC_X_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickY(void *handle, LSM303AGR_ACC_Y_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickY(void *handle, LSM303AGR_ACC_Y_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_SRC, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3538,7 +3538,7 @@ status_t LSM303AGR_ACC_R_ClickY(void *handle, LSM303AGR_ACC_Y_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickZ(void *handle, LSM303AGR_ACC_Z_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickZ(void *handle, LSM303AGR_ACC_Z_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_SRC, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3555,7 +3555,7 @@ status_t LSM303AGR_ACC_R_ClickZ(void *handle, LSM303AGR_ACC_Z_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickSign(void *handle, LSM303AGR_ACC_SIGN_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickSign(void *handle, LSM303AGR_ACC_SIGN_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_SRC, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3572,7 +3572,7 @@ status_t LSM303AGR_ACC_R_ClickSign(void *handle, LSM303AGR_ACC_SIGN_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_SingleCLICK(void *handle, LSM303AGR_ACC_SCLICK_t *value)
+mems_status_t LSM303AGR_ACC_R_SingleCLICK(void *handle, LSM303AGR_ACC_SCLICK_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_SRC, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3589,7 +3589,7 @@ status_t LSM303AGR_ACC_R_SingleCLICK(void *handle, LSM303AGR_ACC_SCLICK_t *value
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_DoubleCLICK(void *handle, LSM303AGR_ACC_DCLICK_t *value)
+mems_status_t LSM303AGR_ACC_R_DoubleCLICK(void *handle, LSM303AGR_ACC_DCLICK_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_SRC, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3606,7 +3606,7 @@ status_t LSM303AGR_ACC_R_DoubleCLICK(void *handle, LSM303AGR_ACC_DCLICK_t *value
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_CLICK_IA(void *handle, LSM303AGR_ACC_CLICK_IA_t *value)
+mems_status_t LSM303AGR_ACC_R_CLICK_IA(void *handle, LSM303AGR_ACC_CLICK_IA_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_SRC, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3622,7 +3622,7 @@ status_t LSM303AGR_ACC_R_CLICK_IA(void *handle, LSM303AGR_ACC_CLICK_IA_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ClickThreshold(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ClickThreshold(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3649,7 +3649,7 @@ status_t  LSM303AGR_ACC_W_ClickThreshold(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickThreshold(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickThreshold(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_CLICK_THS, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3666,7 +3666,7 @@ status_t LSM303AGR_ACC_R_ClickThreshold(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ClickTimeLimit(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ClickTimeLimit(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3693,7 +3693,7 @@ status_t  LSM303AGR_ACC_W_ClickTimeLimit(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickTimeLimit(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickTimeLimit(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_TIME_LIMIT, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3710,7 +3710,7 @@ status_t LSM303AGR_ACC_R_ClickTimeLimit(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ClickTimeLatency(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ClickTimeLatency(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3737,7 +3737,7 @@ status_t  LSM303AGR_ACC_W_ClickTimeLatency(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickTimeLatency(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickTimeLatency(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_TIME_LATENCY, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3754,7 +3754,7 @@ status_t LSM303AGR_ACC_R_ClickTimeLatency(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_ACC_W_ClickTimeWindow(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_ACC_W_ClickTimeWindow(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -3781,7 +3781,7 @@ status_t  LSM303AGR_ACC_W_ClickTimeWindow(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_ACC_R_ClickTimeWindow(void *handle, u8_t *value)
+mems_status_t LSM303AGR_ACC_R_ClickTimeWindow(void *handle, u8_t *value)
 {
  if( !LSM303AGR_ACC_ReadReg(handle, LSM303AGR_ACC_TIME_WINDOW, (u8_t *)value) )
     return MEMS_ERROR;
@@ -3792,13 +3792,13 @@ status_t LSM303AGR_ACC_R_ClickTimeWindow(void *handle, u8_t *value)
   return MEMS_SUCCESS;
 }
 /*******************************************************************************
-* Function Name  : status_t LSM303AGR_ACC_Get_Voltage_ADC(u8_t *buff)
+* Function Name  : mems_status_t LSM303AGR_ACC_Get_Voltage_ADC(u8_t *buff)
 * Description    : Read Voltage_ADC output register
 * Input          : pointer to [u8_t]
 * Output         : Voltage_ADC buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM303AGR_ACC_Get_Voltage_ADC(void *handle, u8_t *buff) 
+mems_status_t LSM303AGR_ACC_Get_Voltage_ADC(void *handle, u8_t *buff) 
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -3820,13 +3820,13 @@ status_t LSM303AGR_ACC_Get_Voltage_ADC(void *handle, u8_t *buff)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM303AGR_ACC_Get_Raw_Acceleration(u8_t *buff)
+* Function Name  : mems_status_t LSM303AGR_ACC_Get_Raw_Acceleration(u8_t *buff)
 * Description    : Read Acceleration output register
 * Input          : pointer to [u8_t]
 * Output         : Acceleration buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM303AGR_ACC_Get_Raw_Acceleration(void *handle, u8_t *buff) 
+mems_status_t LSM303AGR_ACC_Get_Raw_Acceleration(void *handle, u8_t *buff) 
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -3880,7 +3880,7 @@ const long long LSM303AGR_ACC_Sensitivity_List[3][4] = {
 /*
  * Values returned are espressed in mg.
  */
-status_t LSM303AGR_ACC_Get_Acceleration(void *handle, int *buff)
+mems_status_t LSM303AGR_ACC_Get_Acceleration(void *handle, int *buff)
 {
   Type3Axis16bit_U raw_data_tmp;
   u8_t op_mode = 0, fs_mode = 0, shift = 0;

--- a/src/LSM303AGR_ACC_driver.h
+++ b/src/LSM303AGR_ACC_driver.h
@@ -85,7 +85,7 @@ typedef union{
 typedef enum {
   MEMS_SUCCESS = 0x01,
   MEMS_ERROR   = 0x00	
-} status_t;
+} mems_status_t;
 
 #endif /*__SHARED__TYPES*/
 
@@ -107,8 +107,8 @@ void LSM303AGR_ACC_SwapHighLowByte(u8_t *bufferToSwap, u8_t numberOfByte, u8_t d
 
 /* Public Function Prototypes ------------------------------------------------*/
 
-status_t LSM303AGR_ACC_ReadReg( void *handle, u8_t Reg, u8_t* Data );
-status_t LSM303AGR_ACC_WriteReg( void *handle, u8_t Reg, u8_t Data ); 
+mems_status_t LSM303AGR_ACC_ReadReg( void *handle, u8_t Reg, u8_t* Data );
+mems_status_t LSM303AGR_ACC_WriteReg( void *handle, u8_t Reg, u8_t Data ); 
 
 
 /************** Device Register  *******************/
@@ -165,7 +165,7 @@ typedef enum {
 } LSM303AGR_ACC_1DA_t;
 
 #define  	LSM303AGR_ACC_1DA_MASK  	0x01
-status_t LSM303AGR_ACC_R_x_data_avail(void *handle, LSM303AGR_ACC_1DA_t *value);
+mems_status_t LSM303AGR_ACC_R_x_data_avail(void *handle, LSM303AGR_ACC_1DA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG_AUX
@@ -179,7 +179,7 @@ typedef enum {
 } LSM303AGR_ACC_2DA__t;
 
 #define  	LSM303AGR_ACC_2DA__MASK  	0x02
-status_t LSM303AGR_ACC_R_y_data_avail(void *handle, LSM303AGR_ACC_2DA__t *value);
+mems_status_t LSM303AGR_ACC_R_y_data_avail(void *handle, LSM303AGR_ACC_2DA__t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG_AUX
@@ -193,7 +193,7 @@ typedef enum {
 } LSM303AGR_ACC_3DA__t;
 
 #define  	LSM303AGR_ACC_3DA__MASK  	0x04
-status_t LSM303AGR_ACC_R_z_data_avail(void *handle, LSM303AGR_ACC_3DA__t *value);
+mems_status_t LSM303AGR_ACC_R_z_data_avail(void *handle, LSM303AGR_ACC_3DA__t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG_AUX
@@ -207,7 +207,7 @@ typedef enum {
 } LSM303AGR_ACC_321DA__t;
 
 #define  	LSM303AGR_ACC_321DA__MASK  	0x08
-status_t LSM303AGR_ACC_R_xyz_data_avail(void *handle, LSM303AGR_ACC_321DA__t *value);
+mems_status_t LSM303AGR_ACC_R_xyz_data_avail(void *handle, LSM303AGR_ACC_321DA__t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG_AUX
@@ -221,7 +221,7 @@ typedef enum {
 } LSM303AGR_ACC_1OR__t;
 
 #define  	LSM303AGR_ACC_1OR__MASK  	0x10
-status_t LSM303AGR_ACC_R_DataXOverrun(void *handle, LSM303AGR_ACC_1OR__t *value);
+mems_status_t LSM303AGR_ACC_R_DataXOverrun(void *handle, LSM303AGR_ACC_1OR__t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG_AUX
@@ -235,7 +235,7 @@ typedef enum {
 } LSM303AGR_ACC_2OR__t;
 
 #define  	LSM303AGR_ACC_2OR__MASK  	0x20
-status_t LSM303AGR_ACC_R_DataYOverrun(void *handle, LSM303AGR_ACC_2OR__t *value);
+mems_status_t LSM303AGR_ACC_R_DataYOverrun(void *handle, LSM303AGR_ACC_2OR__t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG_AUX
@@ -249,7 +249,7 @@ typedef enum {
 } LSM303AGR_ACC_3OR__t;
 
 #define  	LSM303AGR_ACC_3OR__MASK  	0x40
-status_t LSM303AGR_ACC_R_DataZOverrun(void *handle, LSM303AGR_ACC_3OR__t *value);
+mems_status_t LSM303AGR_ACC_R_DataZOverrun(void *handle, LSM303AGR_ACC_3OR__t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG_AUX
@@ -263,7 +263,7 @@ typedef enum {
 } LSM303AGR_ACC_321OR__t;
 
 #define  	LSM303AGR_ACC_321OR__MASK  	0x80
-status_t LSM303AGR_ACC_R_DataXYZOverrun(void *handle, LSM303AGR_ACC_321OR__t *value);
+mems_status_t LSM303AGR_ACC_R_DataXYZOverrun(void *handle, LSM303AGR_ACC_321OR__t *value);
 
 /*******************************************************************************
 * Register      : INT_COUNTER_REG
@@ -273,7 +273,7 @@ status_t LSM303AGR_ACC_R_DataXYZOverrun(void *handle, LSM303AGR_ACC_321OR__t *va
 *******************************************************************************/
 #define  	LSM303AGR_ACC_IC_MASK  	0xFF
 #define  	LSM303AGR_ACC_IC_POSITION  	0
-status_t LSM303AGR_ACC_R_int_counter(void *handle, u8_t *value);
+mems_status_t LSM303AGR_ACC_R_int_counter(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : WHO_AM_I
@@ -283,7 +283,7 @@ status_t LSM303AGR_ACC_R_int_counter(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_ACC_WHO_AM_I_MASK  	0xFF
 #define  	LSM303AGR_ACC_WHO_AM_I_POSITION  	0
-status_t LSM303AGR_ACC_R_WHO_AM_I(void *handle, u8_t *value);
+mems_status_t LSM303AGR_ACC_R_WHO_AM_I(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : TEMP_CFG_REG
@@ -297,8 +297,8 @@ typedef enum {
 } LSM303AGR_ACC_TEMP_EN_t;
 
 #define  	LSM303AGR_ACC_TEMP_EN_MASK  	0x40
-status_t  LSM303AGR_ACC_W_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t newValue);
-status_t LSM303AGR_ACC_R_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t *value);
+mems_status_t  LSM303AGR_ACC_W_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t newValue);
+mems_status_t LSM303AGR_ACC_R_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t *value);
 
 /*******************************************************************************
 * Register      : TEMP_CFG_REG
@@ -312,8 +312,8 @@ typedef enum {
 } LSM303AGR_ACC_ADC_PD_t;
 
 #define  	LSM303AGR_ACC_ADC_PD_MASK  	0x80
-status_t  LSM303AGR_ACC_W_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t newValue);
-status_t LSM303AGR_ACC_R_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t *value);
+mems_status_t  LSM303AGR_ACC_W_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t newValue);
+mems_status_t LSM303AGR_ACC_R_ADC_PD(void *handle, LSM303AGR_ACC_ADC_PD_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG1
@@ -327,8 +327,8 @@ typedef enum {
 } LSM303AGR_ACC_XEN_t;
 
 #define  	LSM303AGR_ACC_XEN_MASK  	0x01
-status_t  LSM303AGR_ACC_W_XEN(void *handle, LSM303AGR_ACC_XEN_t newValue);
-status_t LSM303AGR_ACC_R_XEN(void *handle, LSM303AGR_ACC_XEN_t *value);
+mems_status_t  LSM303AGR_ACC_W_XEN(void *handle, LSM303AGR_ACC_XEN_t newValue);
+mems_status_t LSM303AGR_ACC_R_XEN(void *handle, LSM303AGR_ACC_XEN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG1
@@ -342,8 +342,8 @@ typedef enum {
 } LSM303AGR_ACC_YEN_t;
 
 #define  	LSM303AGR_ACC_YEN_MASK  	0x02
-status_t  LSM303AGR_ACC_W_YEN(void *handle, LSM303AGR_ACC_YEN_t newValue);
-status_t LSM303AGR_ACC_R_YEN(void *handle, LSM303AGR_ACC_YEN_t *value);
+mems_status_t  LSM303AGR_ACC_W_YEN(void *handle, LSM303AGR_ACC_YEN_t newValue);
+mems_status_t LSM303AGR_ACC_R_YEN(void *handle, LSM303AGR_ACC_YEN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG1
@@ -357,8 +357,8 @@ typedef enum {
 } LSM303AGR_ACC_ZEN_t;
 
 #define  	LSM303AGR_ACC_ZEN_MASK  	0x04
-status_t  LSM303AGR_ACC_W_ZEN(void *handle, LSM303AGR_ACC_ZEN_t newValue);
-status_t LSM303AGR_ACC_R_ZEN(void *handle, LSM303AGR_ACC_ZEN_t *value);
+mems_status_t  LSM303AGR_ACC_W_ZEN(void *handle, LSM303AGR_ACC_ZEN_t newValue);
+mems_status_t LSM303AGR_ACC_R_ZEN(void *handle, LSM303AGR_ACC_ZEN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG1
@@ -372,8 +372,8 @@ typedef enum {
 } LSM303AGR_ACC_LPEN_t;
 
 #define  	LSM303AGR_ACC_LPEN_MASK  	0x08
-status_t  LSM303AGR_ACC_W_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t newValue);
-status_t LSM303AGR_ACC_R_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t *value);
+mems_status_t  LSM303AGR_ACC_W_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t newValue);
+mems_status_t LSM303AGR_ACC_R_LOWPWR_EN(void *handle, LSM303AGR_ACC_LPEN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG1
@@ -395,8 +395,8 @@ typedef enum {
 } LSM303AGR_ACC_ODR_t;
 
 #define  	LSM303AGR_ACC_ODR_MASK  	0xF0
-status_t  LSM303AGR_ACC_W_ODR(void *handle, LSM303AGR_ACC_ODR_t newValue);
-status_t LSM303AGR_ACC_R_ODR(void *handle, LSM303AGR_ACC_ODR_t *value);
+mems_status_t  LSM303AGR_ACC_W_ODR(void *handle, LSM303AGR_ACC_ODR_t newValue);
+mems_status_t LSM303AGR_ACC_R_ODR(void *handle, LSM303AGR_ACC_ODR_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG2
@@ -410,8 +410,8 @@ typedef enum {
 } LSM303AGR_ACC_HPIS1_t;
 
 #define  	LSM303AGR_ACC_HPIS1_MASK  	0x01
-status_t  LSM303AGR_ACC_W_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t newValue);
-status_t LSM303AGR_ACC_R_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t *value);
+mems_status_t  LSM303AGR_ACC_W_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t newValue);
+mems_status_t LSM303AGR_ACC_R_hpf_aoi_en_int1(void *handle, LSM303AGR_ACC_HPIS1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG2
@@ -425,8 +425,8 @@ typedef enum {
 } LSM303AGR_ACC_HPIS2_t;
 
 #define  	LSM303AGR_ACC_HPIS2_MASK  	0x02
-status_t  LSM303AGR_ACC_W_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t newValue);
-status_t LSM303AGR_ACC_R_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t *value);
+mems_status_t  LSM303AGR_ACC_W_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t newValue);
+mems_status_t LSM303AGR_ACC_R_hpf_aoi_en_int2(void *handle, LSM303AGR_ACC_HPIS2_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG2
@@ -440,8 +440,8 @@ typedef enum {
 } LSM303AGR_ACC_HPCLICK_t;
 
 #define  	LSM303AGR_ACC_HPCLICK_MASK  	0x04
-status_t  LSM303AGR_ACC_W_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t newValue);
-status_t LSM303AGR_ACC_R_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t *value);
+mems_status_t  LSM303AGR_ACC_W_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t newValue);
+mems_status_t LSM303AGR_ACC_R_hpf_click_en(void *handle, LSM303AGR_ACC_HPCLICK_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG2
@@ -455,8 +455,8 @@ typedef enum {
 } LSM303AGR_ACC_FDS_t;
 
 #define  	LSM303AGR_ACC_FDS_MASK  	0x08
-status_t  LSM303AGR_ACC_W_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t newValue);
-status_t LSM303AGR_ACC_R_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t *value);
+mems_status_t  LSM303AGR_ACC_W_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t newValue);
+mems_status_t LSM303AGR_ACC_R_Data_Filter(void *handle, LSM303AGR_ACC_FDS_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG2
@@ -472,8 +472,8 @@ typedef enum {
 } LSM303AGR_ACC_HPCF_t;
 
 #define  	LSM303AGR_ACC_HPCF_MASK  	0x30
-status_t  LSM303AGR_ACC_W_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t newValue);
-status_t LSM303AGR_ACC_R_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t *value);
+mems_status_t  LSM303AGR_ACC_W_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t newValue);
+mems_status_t LSM303AGR_ACC_R_hpf_cutoff_freq(void *handle, LSM303AGR_ACC_HPCF_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG2
@@ -489,8 +489,8 @@ typedef enum {
 } LSM303AGR_ACC_HPM_t;
 
 #define  	LSM303AGR_ACC_HPM_MASK  	0xC0
-status_t  LSM303AGR_ACC_W_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t newValue);
-status_t LSM303AGR_ACC_R_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t *value);
+mems_status_t  LSM303AGR_ACC_W_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t newValue);
+mems_status_t LSM303AGR_ACC_R_hpf_mode(void *handle, LSM303AGR_ACC_HPM_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG3
@@ -504,8 +504,8 @@ typedef enum {
 } LSM303AGR_ACC_I1_OVERRUN_t;
 
 #define  	LSM303AGR_ACC_I1_OVERRUN_MASK  	0x02
-status_t  LSM303AGR_ACC_W_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_Overrun_on_INT1(void *handle, LSM303AGR_ACC_I1_OVERRUN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG3
@@ -519,8 +519,8 @@ typedef enum {
 } LSM303AGR_ACC_I1_WTM_t;
 
 #define  	LSM303AGR_ACC_I1_WTM_MASK  	0x04
-status_t  LSM303AGR_ACC_W_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_Watermark_on_INT1(void *handle, LSM303AGR_ACC_I1_WTM_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG3
@@ -534,8 +534,8 @@ typedef enum {
 } LSM303AGR_ACC_I1_DRDY2_t;
 
 #define  	LSM303AGR_ACC_I1_DRDY2_MASK  	0x08
-status_t  LSM303AGR_ACC_W_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_DRDY2_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY2_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG3
@@ -549,8 +549,8 @@ typedef enum {
 } LSM303AGR_ACC_I1_DRDY1_t;
 
 #define  	LSM303AGR_ACC_I1_DRDY1_MASK  	0x10
-status_t  LSM303AGR_ACC_W_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_DRDY1_on_INT1(void *handle, LSM303AGR_ACC_I1_DRDY1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG3
@@ -564,8 +564,8 @@ typedef enum {
 } LSM303AGR_ACC_I1_AOI2_t;
 
 #define  	LSM303AGR_ACC_I1_AOI2_MASK  	0x20
-status_t  LSM303AGR_ACC_W_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_AOL2_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI2_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG3
@@ -579,8 +579,8 @@ typedef enum {
 } LSM303AGR_ACC_I1_AOI1_t;
 
 #define  	LSM303AGR_ACC_I1_AOI1_MASK  	0x40
-status_t  LSM303AGR_ACC_W_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_AOL1_on_INT1(void *handle, LSM303AGR_ACC_I1_AOI1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG3
@@ -594,8 +594,8 @@ typedef enum {
 } LSM303AGR_ACC_I1_CLICK_t;
 
 #define  	LSM303AGR_ACC_I1_CLICK_MASK  	0x80
-status_t  LSM303AGR_ACC_W_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_Click_on_INT1(void *handle, LSM303AGR_ACC_I1_CLICK_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG4
@@ -609,8 +609,8 @@ typedef enum {
 } LSM303AGR_ACC_SIM_t;
 
 #define  	LSM303AGR_ACC_SIM_MASK  	0x01
-status_t  LSM303AGR_ACC_W_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t newValue);
-status_t LSM303AGR_ACC_R_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t *value);
+mems_status_t  LSM303AGR_ACC_W_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t newValue);
+mems_status_t LSM303AGR_ACC_R_SPI_mode(void *handle, LSM303AGR_ACC_SIM_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG4
@@ -626,8 +626,8 @@ typedef enum {
 } LSM303AGR_ACC_ST_t;
 
 #define  	LSM303AGR_ACC_ST_MASK  	0x06
-status_t  LSM303AGR_ACC_W_SelfTest(void *handle, LSM303AGR_ACC_ST_t newValue);
-status_t LSM303AGR_ACC_R_SelfTest(void *handle, LSM303AGR_ACC_ST_t *value);
+mems_status_t  LSM303AGR_ACC_W_SelfTest(void *handle, LSM303AGR_ACC_ST_t newValue);
+mems_status_t LSM303AGR_ACC_R_SelfTest(void *handle, LSM303AGR_ACC_ST_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG4
@@ -641,8 +641,8 @@ typedef enum {
 } LSM303AGR_ACC_HR_t;
 
 #define  	LSM303AGR_ACC_HR_MASK  	0x08
-status_t  LSM303AGR_ACC_W_HiRes(void *handle, LSM303AGR_ACC_HR_t newValue);
-status_t LSM303AGR_ACC_R_HiRes(void *handle, LSM303AGR_ACC_HR_t *value);
+mems_status_t  LSM303AGR_ACC_W_HiRes(void *handle, LSM303AGR_ACC_HR_t newValue);
+mems_status_t LSM303AGR_ACC_R_HiRes(void *handle, LSM303AGR_ACC_HR_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG4
@@ -658,8 +658,8 @@ typedef enum {
 } LSM303AGR_ACC_FS_t;
 
 #define  	LSM303AGR_ACC_FS_MASK  	0x30
-status_t  LSM303AGR_ACC_W_FullScale(void *handle, LSM303AGR_ACC_FS_t newValue);
-status_t LSM303AGR_ACC_R_FullScale(void *handle, LSM303AGR_ACC_FS_t *value);
+mems_status_t  LSM303AGR_ACC_W_FullScale(void *handle, LSM303AGR_ACC_FS_t newValue);
+mems_status_t LSM303AGR_ACC_R_FullScale(void *handle, LSM303AGR_ACC_FS_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG4
@@ -673,8 +673,8 @@ typedef enum {
 } LSM303AGR_ACC_BLE_t;
 
 #define  	LSM303AGR_ACC_BLE_MASK  	0x40
-status_t  LSM303AGR_ACC_W_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t newValue);
-status_t LSM303AGR_ACC_R_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t *value);
+mems_status_t  LSM303AGR_ACC_W_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t newValue);
+mems_status_t LSM303AGR_ACC_R_LittleBigEndian(void *handle, LSM303AGR_ACC_BLE_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG4
@@ -688,8 +688,8 @@ typedef enum {
 } LSM303AGR_ACC_BDU_t;
 
 #define  	LSM303AGR_ACC_BDU_MASK  	0x80
-status_t  LSM303AGR_ACC_W_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t newValue);
-status_t LSM303AGR_ACC_R_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t *value);
+mems_status_t  LSM303AGR_ACC_W_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t newValue);
+mems_status_t LSM303AGR_ACC_R_BlockDataUpdate(void *handle, LSM303AGR_ACC_BDU_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG5
@@ -703,8 +703,8 @@ typedef enum {
 } LSM303AGR_ACC_D4D_INT2_t;
 
 #define  	LSM303AGR_ACC_D4D_INT2_MASK  	0x01
-status_t  LSM303AGR_ACC_W_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t newValue);
-status_t LSM303AGR_ACC_R_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t *value);
+mems_status_t  LSM303AGR_ACC_W_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t newValue);
+mems_status_t LSM303AGR_ACC_R_4D_on_INT2(void *handle, LSM303AGR_ACC_D4D_INT2_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG5
@@ -718,8 +718,8 @@ typedef enum {
 } LSM303AGR_ACC_LIR_INT2_t;
 
 #define  	LSM303AGR_ACC_LIR_INT2_MASK  	0x02
-status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t newValue);
-status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t *value);
+mems_status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t newValue);
+mems_status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT2(void *handle, LSM303AGR_ACC_LIR_INT2_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG5
@@ -733,8 +733,8 @@ typedef enum {
 } LSM303AGR_ACC_D4D_INT1_t;
 
 #define  	LSM303AGR_ACC_D4D_INT1_MASK  	0x04
-status_t  LSM303AGR_ACC_W_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t newValue);
-status_t LSM303AGR_ACC_R_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t *value);
+mems_status_t  LSM303AGR_ACC_W_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t newValue);
+mems_status_t LSM303AGR_ACC_R_4D_on_INT1(void *handle, LSM303AGR_ACC_D4D_INT1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG5
@@ -748,8 +748,8 @@ typedef enum {
 } LSM303AGR_ACC_LIR_INT1_t;
 
 #define  	LSM303AGR_ACC_LIR_INT1_MASK  	0x08
-status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t newValue);
-status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t *value);
+mems_status_t  LSM303AGR_ACC_W_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t newValue);
+mems_status_t LSM303AGR_ACC_R_LatchInterrupt_on_INT1(void *handle, LSM303AGR_ACC_LIR_INT1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG5
@@ -763,8 +763,8 @@ typedef enum {
 } LSM303AGR_ACC_FIFO_EN_t;
 
 #define  	LSM303AGR_ACC_FIFO_EN_MASK  	0x40
-status_t  LSM303AGR_ACC_W_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t newValue);
-status_t LSM303AGR_ACC_R_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t *value);
+mems_status_t  LSM303AGR_ACC_W_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t newValue);
+mems_status_t LSM303AGR_ACC_R_FIFO_EN(void *handle, LSM303AGR_ACC_FIFO_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG5
@@ -778,8 +778,8 @@ typedef enum {
 } LSM303AGR_ACC_BOOT_t;
 
 #define  	LSM303AGR_ACC_BOOT_MASK  	0x80
-status_t  LSM303AGR_ACC_W_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t newValue);
-status_t LSM303AGR_ACC_R_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t *value);
+mems_status_t  LSM303AGR_ACC_W_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t newValue);
+mems_status_t LSM303AGR_ACC_R_RebootMemory(void *handle, LSM303AGR_ACC_BOOT_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG6
@@ -793,8 +793,8 @@ typedef enum {
 } LSM303AGR_ACC_H_LACTIVE_t;
 
 #define  	LSM303AGR_ACC_H_LACTIVE_MASK  	0x02
-status_t  LSM303AGR_ACC_W_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t newValue);
-status_t LSM303AGR_ACC_R_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t *value);
+mems_status_t  LSM303AGR_ACC_W_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t newValue);
+mems_status_t LSM303AGR_ACC_R_IntActive(void *handle, LSM303AGR_ACC_H_LACTIVE_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG6
@@ -808,8 +808,8 @@ typedef enum {
 } LSM303AGR_ACC_P2_ACT_t;
 
 #define  	LSM303AGR_ACC_P2_ACT_MASK  	0x08
-status_t  LSM303AGR_ACC_W_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t newValue);
-status_t LSM303AGR_ACC_R_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t *value);
+mems_status_t  LSM303AGR_ACC_W_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t newValue);
+mems_status_t LSM303AGR_ACC_R_P2_ACT(void *handle, LSM303AGR_ACC_P2_ACT_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG6
@@ -823,8 +823,8 @@ typedef enum {
 } LSM303AGR_ACC_BOOT_I1_t;
 
 #define  	LSM303AGR_ACC_BOOT_I1_MASK  	0x10
-status_t  LSM303AGR_ACC_W_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t newValue);
-status_t LSM303AGR_ACC_R_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t *value);
+mems_status_t  LSM303AGR_ACC_W_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t newValue);
+mems_status_t LSM303AGR_ACC_R_Boot_on_INT2(void *handle, LSM303AGR_ACC_BOOT_I1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG6
@@ -838,8 +838,8 @@ typedef enum {
 } LSM303AGR_ACC_I2_INT2_t;
 
 #define  	LSM303AGR_ACC_I2_INT2_MASK  	0x20
-status_t  LSM303AGR_ACC_W_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t newValue);
-status_t LSM303AGR_ACC_R_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t *value);
+mems_status_t  LSM303AGR_ACC_W_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t newValue);
+mems_status_t LSM303AGR_ACC_R_I2_on_INT2(void *handle, LSM303AGR_ACC_I2_INT2_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG6
@@ -853,8 +853,8 @@ typedef enum {
 } LSM303AGR_ACC_I2_INT1_t;
 
 #define  	LSM303AGR_ACC_I2_INT1_MASK  	0x40
-status_t  LSM303AGR_ACC_W_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t newValue);
-status_t LSM303AGR_ACC_R_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t *value);
+mems_status_t  LSM303AGR_ACC_W_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t newValue);
+mems_status_t LSM303AGR_ACC_R_I2_on_INT1(void *handle, LSM303AGR_ACC_I2_INT1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL_REG6
@@ -868,8 +868,8 @@ typedef enum {
 } LSM303AGR_ACC_I2_CLICKEN_t;
 
 #define  	LSM303AGR_ACC_I2_CLICKEN_MASK  	0x80
-status_t  LSM303AGR_ACC_W_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t newValue);
-status_t LSM303AGR_ACC_R_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t *value);
+mems_status_t  LSM303AGR_ACC_W_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t newValue);
+mems_status_t LSM303AGR_ACC_R_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t *value);
 
 /*******************************************************************************
 * Register      : REFERENCE
@@ -879,8 +879,8 @@ status_t LSM303AGR_ACC_R_Click_on_INT2(void *handle, LSM303AGR_ACC_I2_CLICKEN_t 
 *******************************************************************************/
 #define  	LSM303AGR_ACC_REF_MASK  	0xFF
 #define  	LSM303AGR_ACC_REF_POSITION  	0
-status_t  LSM303AGR_ACC_W_ReferenceVal(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_ReferenceVal(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_ReferenceVal(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_ReferenceVal(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -894,7 +894,7 @@ typedef enum {
 } LSM303AGR_ACC_XDA_t;
 
 #define  	LSM303AGR_ACC_XDA_MASK  	0x01
-status_t LSM303AGR_ACC_R_XDataAvail(void *handle, LSM303AGR_ACC_XDA_t *value);
+mems_status_t LSM303AGR_ACC_R_XDataAvail(void *handle, LSM303AGR_ACC_XDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -908,7 +908,7 @@ typedef enum {
 } LSM303AGR_ACC_YDA_t;
 
 #define  	LSM303AGR_ACC_YDA_MASK  	0x02
-status_t LSM303AGR_ACC_R_YDataAvail(void *handle, LSM303AGR_ACC_YDA_t *value);
+mems_status_t LSM303AGR_ACC_R_YDataAvail(void *handle, LSM303AGR_ACC_YDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -922,7 +922,7 @@ typedef enum {
 } LSM303AGR_ACC_ZDA_t;
 
 #define  	LSM303AGR_ACC_ZDA_MASK  	0x04
-status_t LSM303AGR_ACC_R_ZDataAvail(void *handle, LSM303AGR_ACC_ZDA_t *value);
+mems_status_t LSM303AGR_ACC_R_ZDataAvail(void *handle, LSM303AGR_ACC_ZDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -936,7 +936,7 @@ typedef enum {
 } LSM303AGR_ACC_ZYXDA_t;
 
 #define  	LSM303AGR_ACC_ZYXDA_MASK  	0x08
-status_t LSM303AGR_ACC_R_XYZDataAvail(void *handle, LSM303AGR_ACC_ZYXDA_t *value);
+mems_status_t LSM303AGR_ACC_R_XYZDataAvail(void *handle, LSM303AGR_ACC_ZYXDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -950,7 +950,7 @@ typedef enum {
 } LSM303AGR_ACC_XOR_t;
 
 #define  	LSM303AGR_ACC_XOR_MASK  	0x10
-status_t LSM303AGR_ACC_R_XDataOverrun(void *handle, LSM303AGR_ACC_XOR_t *value);
+mems_status_t LSM303AGR_ACC_R_XDataOverrun(void *handle, LSM303AGR_ACC_XOR_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -964,7 +964,7 @@ typedef enum {
 } LSM303AGR_ACC_YOR_t;
 
 #define  	LSM303AGR_ACC_YOR_MASK  	0x20
-status_t LSM303AGR_ACC_R_YDataOverrun(void *handle, LSM303AGR_ACC_YOR_t *value);
+mems_status_t LSM303AGR_ACC_R_YDataOverrun(void *handle, LSM303AGR_ACC_YOR_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -978,7 +978,7 @@ typedef enum {
 } LSM303AGR_ACC_ZOR_t;
 
 #define  	LSM303AGR_ACC_ZOR_MASK  	0x40
-status_t LSM303AGR_ACC_R_ZDataOverrun(void *handle, LSM303AGR_ACC_ZOR_t *value);
+mems_status_t LSM303AGR_ACC_R_ZDataOverrun(void *handle, LSM303AGR_ACC_ZOR_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG2
@@ -992,7 +992,7 @@ typedef enum {
 } LSM303AGR_ACC_ZYXOR_t;
 
 #define  	LSM303AGR_ACC_ZYXOR_MASK  	0x80
-status_t LSM303AGR_ACC_R_XYZDataOverrun(void *handle, LSM303AGR_ACC_ZYXOR_t *value);
+mems_status_t LSM303AGR_ACC_R_XYZDataOverrun(void *handle, LSM303AGR_ACC_ZYXOR_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL_REG
@@ -1002,8 +1002,8 @@ status_t LSM303AGR_ACC_R_XYZDataOverrun(void *handle, LSM303AGR_ACC_ZYXOR_t *val
 *******************************************************************************/
 #define  	LSM303AGR_ACC_FTH_MASK  	0x1F
 #define  	LSM303AGR_ACC_FTH_POSITION  	0
-status_t  LSM303AGR_ACC_W_FifoThreshold(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_FifoThreshold(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_FifoThreshold(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_FifoThreshold(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL_REG
@@ -1017,8 +1017,8 @@ typedef enum {
 } LSM303AGR_ACC_TR_t;
 
 #define  	LSM303AGR_ACC_TR_MASK  	0x20
-status_t  LSM303AGR_ACC_W_TriggerSel(void *handle, LSM303AGR_ACC_TR_t newValue);
-status_t LSM303AGR_ACC_R_TriggerSel(void *handle, LSM303AGR_ACC_TR_t *value);
+mems_status_t  LSM303AGR_ACC_W_TriggerSel(void *handle, LSM303AGR_ACC_TR_t newValue);
+mems_status_t LSM303AGR_ACC_R_TriggerSel(void *handle, LSM303AGR_ACC_TR_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL_REG
@@ -1034,8 +1034,8 @@ typedef enum {
 } LSM303AGR_ACC_FM_t;
 
 #define  	LSM303AGR_ACC_FM_MASK  	0xC0
-status_t  LSM303AGR_ACC_W_FifoMode(void *handle, LSM303AGR_ACC_FM_t newValue);
-status_t LSM303AGR_ACC_R_FifoMode(void *handle, LSM303AGR_ACC_FM_t *value);
+mems_status_t  LSM303AGR_ACC_W_FifoMode(void *handle, LSM303AGR_ACC_FM_t newValue);
+mems_status_t LSM303AGR_ACC_R_FifoMode(void *handle, LSM303AGR_ACC_FM_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_SRC_REG
@@ -1045,7 +1045,7 @@ status_t LSM303AGR_ACC_R_FifoMode(void *handle, LSM303AGR_ACC_FM_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_ACC_FSS_MASK  	0x1F
 #define  	LSM303AGR_ACC_FSS_POSITION  	0
-status_t LSM303AGR_ACC_R_FifoSamplesAvail(void *handle, u8_t *value);
+mems_status_t LSM303AGR_ACC_R_FifoSamplesAvail(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_SRC_REG
@@ -1059,7 +1059,7 @@ typedef enum {
 } LSM303AGR_ACC_EMPTY_t;
 
 #define  	LSM303AGR_ACC_EMPTY_MASK  	0x20
-status_t LSM303AGR_ACC_R_FifoEmpty(void *handle, LSM303AGR_ACC_EMPTY_t *value);
+mems_status_t LSM303AGR_ACC_R_FifoEmpty(void *handle, LSM303AGR_ACC_EMPTY_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_SRC_REG
@@ -1073,7 +1073,7 @@ typedef enum {
 } LSM303AGR_ACC_OVRN_FIFO_t;
 
 #define  	LSM303AGR_ACC_OVRN_FIFO_MASK  	0x40
-status_t LSM303AGR_ACC_R_FifoOverrun(void *handle, LSM303AGR_ACC_OVRN_FIFO_t *value);
+mems_status_t LSM303AGR_ACC_R_FifoOverrun(void *handle, LSM303AGR_ACC_OVRN_FIFO_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_SRC_REG
@@ -1087,7 +1087,7 @@ typedef enum {
 } LSM303AGR_ACC_WTM_t;
 
 #define  	LSM303AGR_ACC_WTM_MASK  	0x80
-status_t LSM303AGR_ACC_R_WatermarkLevel(void *handle, LSM303AGR_ACC_WTM_t *value);
+mems_status_t LSM303AGR_ACC_R_WatermarkLevel(void *handle, LSM303AGR_ACC_WTM_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1101,10 +1101,10 @@ typedef enum {
 } LSM303AGR_ACC_XLIE_t;
 
 #define  	LSM303AGR_ACC_XLIE_MASK  	0x01
-status_t  LSM303AGR_ACC_W_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue);
-status_t LSM303AGR_ACC_R_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value);
-status_t  LSM303AGR_ACC_W_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue);
-status_t LSM303AGR_ACC_R_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2EnXLo(void *handle, LSM303AGR_ACC_XLIE_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1118,10 +1118,10 @@ typedef enum {
 } LSM303AGR_ACC_XHIE_t;
 
 #define  	LSM303AGR_ACC_XHIE_MASK  	0x02
-status_t  LSM303AGR_ACC_W_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue);
-status_t LSM303AGR_ACC_R_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value);
-status_t  LSM303AGR_ACC_W_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue);
-status_t LSM303AGR_ACC_R_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2EnXHi(void *handle, LSM303AGR_ACC_XHIE_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1135,10 +1135,10 @@ typedef enum {
 } LSM303AGR_ACC_YLIE_t;
 
 #define  	LSM303AGR_ACC_YLIE_MASK  	0x04
-status_t  LSM303AGR_ACC_W_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue);
-status_t LSM303AGR_ACC_R_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value);
-status_t  LSM303AGR_ACC_W_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue);
-status_t LSM303AGR_ACC_R_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2EnYLo(void *handle, LSM303AGR_ACC_YLIE_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1152,10 +1152,10 @@ typedef enum {
 } LSM303AGR_ACC_YHIE_t;
 
 #define  	LSM303AGR_ACC_YHIE_MASK  	0x08
-status_t  LSM303AGR_ACC_W_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue);
-status_t LSM303AGR_ACC_R_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value);
-status_t  LSM303AGR_ACC_W_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue);
-status_t LSM303AGR_ACC_R_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2EnYHi(void *handle, LSM303AGR_ACC_YHIE_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1169,10 +1169,10 @@ typedef enum {
 } LSM303AGR_ACC_ZLIE_t;
 
 #define  	LSM303AGR_ACC_ZLIE_MASK  	0x10
-status_t  LSM303AGR_ACC_W_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue);
-status_t LSM303AGR_ACC_R_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value);
-status_t  LSM303AGR_ACC_W_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue);
-status_t LSM303AGR_ACC_R_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2EnZLo(void *handle, LSM303AGR_ACC_ZLIE_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1186,10 +1186,10 @@ typedef enum {
 } LSM303AGR_ACC_ZHIE_t;
 
 #define  	LSM303AGR_ACC_ZHIE_MASK  	0x20
-status_t  LSM303AGR_ACC_W_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue);
-status_t LSM303AGR_ACC_R_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value);
-status_t  LSM303AGR_ACC_W_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue);
-status_t LSM303AGR_ACC_R_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2EnZHi(void *handle, LSM303AGR_ACC_ZHIE_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1203,10 +1203,10 @@ typedef enum {
 } LSM303AGR_ACC_6D_t;
 
 #define  	LSM303AGR_ACC_6D_MASK  	0x40
-status_t  LSM303AGR_ACC_W_Int1_6D(void *handle, LSM303AGR_ACC_6D_t newValue);
-status_t LSM303AGR_ACC_R_Int1_6D(void *handle, LSM303AGR_ACC_6D_t *value);
-status_t  LSM303AGR_ACC_W_Int2_6D(void *handle, LSM303AGR_ACC_6D_t newValue);
-status_t LSM303AGR_ACC_R_Int2_6D(void *handle, LSM303AGR_ACC_6D_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1_6D(void *handle, LSM303AGR_ACC_6D_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1_6D(void *handle, LSM303AGR_ACC_6D_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2_6D(void *handle, LSM303AGR_ACC_6D_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2_6D(void *handle, LSM303AGR_ACC_6D_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CFG/INT2_CFG
@@ -1220,10 +1220,10 @@ typedef enum {
 } LSM303AGR_ACC_AOI_t;
 
 #define  	LSM303AGR_ACC_AOI_MASK  	0x80
-status_t  LSM303AGR_ACC_W_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue);
-status_t LSM303AGR_ACC_R_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t *value);
-status_t  LSM303AGR_ACC_W_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue);
-status_t LSM303AGR_ACC_R_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1_AOI(void *handle, LSM303AGR_ACC_AOI_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2_AOI(void *handle, LSM303AGR_ACC_AOI_t *value);
 
 /*******************************************************************************
 * Register      : INT1_SOURCE/INT2_SOURCE
@@ -1237,8 +1237,8 @@ typedef enum {
 } LSM303AGR_ACC_XL_t;
 
 #define  	LSM303AGR_ACC_XL_MASK  	0x01
-status_t LSM303AGR_ACC_R_Int1_Xlo(void *handle, LSM303AGR_ACC_XL_t *value);
-status_t LSM303AGR_ACC_R_Int2_Xlo(void *handle, LSM303AGR_ACC_XL_t *value);
+mems_status_t LSM303AGR_ACC_R_Int1_Xlo(void *handle, LSM303AGR_ACC_XL_t *value);
+mems_status_t LSM303AGR_ACC_R_Int2_Xlo(void *handle, LSM303AGR_ACC_XL_t *value);
 
 /*******************************************************************************
 * Register      : INT1_SOURCE/INT2_SOURCE
@@ -1252,8 +1252,8 @@ typedef enum {
 } LSM303AGR_ACC_XH_t;
 
 #define  	LSM303AGR_ACC_XH_MASK  	0x02
-status_t LSM303AGR_ACC_R_Int1_XHi(void *handle, LSM303AGR_ACC_XH_t *value);
-status_t LSM303AGR_ACC_R_Int2_XHi(void *handle, LSM303AGR_ACC_XH_t *value);
+mems_status_t LSM303AGR_ACC_R_Int1_XHi(void *handle, LSM303AGR_ACC_XH_t *value);
+mems_status_t LSM303AGR_ACC_R_Int2_XHi(void *handle, LSM303AGR_ACC_XH_t *value);
 
 /*******************************************************************************
 * Register      : INT1_SOURCE/INT2_SOURCE
@@ -1267,8 +1267,8 @@ typedef enum {
 } LSM303AGR_ACC_YL_t;
 
 #define  	LSM303AGR_ACC_YL_MASK  	0x04
-status_t LSM303AGR_ACC_R_Int1_YLo(void *handle, LSM303AGR_ACC_YL_t *value);
-status_t LSM303AGR_ACC_R_Int2_YLo(void *handle, LSM303AGR_ACC_YL_t *value);
+mems_status_t LSM303AGR_ACC_R_Int1_YLo(void *handle, LSM303AGR_ACC_YL_t *value);
+mems_status_t LSM303AGR_ACC_R_Int2_YLo(void *handle, LSM303AGR_ACC_YL_t *value);
 
 /*******************************************************************************
 * Register      : INT1_SOURCE/INT2_SOURCE
@@ -1282,8 +1282,8 @@ typedef enum {
 } LSM303AGR_ACC_YH_t;
 
 #define  	LSM303AGR_ACC_YH_MASK  	0x08
-status_t LSM303AGR_ACC_R_Int1_YHi(void *handle, LSM303AGR_ACC_YH_t *value);
-status_t LSM303AGR_ACC_R_Int2_YHi(void *handle, LSM303AGR_ACC_YH_t *value);
+mems_status_t LSM303AGR_ACC_R_Int1_YHi(void *handle, LSM303AGR_ACC_YH_t *value);
+mems_status_t LSM303AGR_ACC_R_Int2_YHi(void *handle, LSM303AGR_ACC_YH_t *value);
 
 /*******************************************************************************
 * Register      : INT1_SOURCE/INT2_SOURCE
@@ -1297,8 +1297,8 @@ typedef enum {
 } LSM303AGR_ACC_ZL_t;
 
 #define  	LSM303AGR_ACC_ZL_MASK  	0x10
-status_t LSM303AGR_ACC_R_Int1_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value);
-status_t LSM303AGR_ACC_R_Int2_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value);
+mems_status_t LSM303AGR_ACC_R_Int1_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value);
+mems_status_t LSM303AGR_ACC_R_Int2_Zlo(void *handle, LSM303AGR_ACC_ZL_t *value);
 
 /*******************************************************************************
 * Register      : INT1_SOURCE/INT2_SOURCE
@@ -1312,8 +1312,8 @@ typedef enum {
 } LSM303AGR_ACC_ZH_t;
 
 #define  	LSM303AGR_ACC_ZH_MASK  	0x20
-status_t LSM303AGR_ACC_R_Int1_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value);
-status_t LSM303AGR_ACC_R_Int2_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value);
+mems_status_t LSM303AGR_ACC_R_Int1_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value);
+mems_status_t LSM303AGR_ACC_R_Int2_ZHi(void *handle, LSM303AGR_ACC_ZH_t *value);
 
 /*******************************************************************************
 * Register      : INT1_SOURCE/INT2_SOURCE
@@ -1327,8 +1327,8 @@ typedef enum {
 } LSM303AGR_ACC_IA_t;
 
 #define  	LSM303AGR_ACC_IA_MASK  	0x40
-status_t LSM303AGR_ACC_R_Int1_IA(void *handle, LSM303AGR_ACC_IA_t *value);
-status_t LSM303AGR_ACC_R_Int2_IA(void *handle, LSM303AGR_ACC_IA_t *value);
+mems_status_t LSM303AGR_ACC_R_Int1_IA(void *handle, LSM303AGR_ACC_IA_t *value);
+mems_status_t LSM303AGR_ACC_R_Int2_IA(void *handle, LSM303AGR_ACC_IA_t *value);
 
 /*******************************************************************************
 * Register      : INT1_THS/INT2_THS
@@ -1338,10 +1338,10 @@ status_t LSM303AGR_ACC_R_Int2_IA(void *handle, LSM303AGR_ACC_IA_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_ACC_THS_MASK  	0x7F
 #define  	LSM303AGR_ACC_THS_POSITION  	0
-status_t  LSM303AGR_ACC_W_Int1_Threshold(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_Int1_Threshold(void *handle, u8_t *value);
-status_t  LSM303AGR_ACC_W_Int2_Threshold(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_Int2_Threshold(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1_Threshold(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1_Threshold(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2_Threshold(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2_Threshold(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : INT1_DURATION/INT2_DURATION
@@ -1351,10 +1351,10 @@ status_t LSM303AGR_ACC_R_Int2_Threshold(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_ACC_D_MASK  	0x7F
 #define  	LSM303AGR_ACC_D_POSITION  	0
-status_t  LSM303AGR_ACC_W_Int1_Duration(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_Int1_Duration(void *handle, u8_t *value);
-status_t  LSM303AGR_ACC_W_Int2_Duration(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_Int2_Duration(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int1_Duration(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int1_Duration(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_Int2_Duration(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_Int2_Duration(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_CFG
@@ -1368,8 +1368,8 @@ typedef enum {
 } LSM303AGR_ACC_XS_t;
 
 #define  	LSM303AGR_ACC_XS_MASK  	0x01
-status_t  LSM303AGR_ACC_W_XSingle(void *handle, LSM303AGR_ACC_XS_t newValue);
-status_t LSM303AGR_ACC_R_XSingle(void *handle, LSM303AGR_ACC_XS_t *value);
+mems_status_t  LSM303AGR_ACC_W_XSingle(void *handle, LSM303AGR_ACC_XS_t newValue);
+mems_status_t LSM303AGR_ACC_R_XSingle(void *handle, LSM303AGR_ACC_XS_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_CFG
@@ -1383,8 +1383,8 @@ typedef enum {
 } LSM303AGR_ACC_XD_t;
 
 #define  	LSM303AGR_ACC_XD_MASK  	0x02
-status_t  LSM303AGR_ACC_W_XDouble(void *handle, LSM303AGR_ACC_XD_t newValue);
-status_t LSM303AGR_ACC_R_XDouble(void *handle, LSM303AGR_ACC_XD_t *value);
+mems_status_t  LSM303AGR_ACC_W_XDouble(void *handle, LSM303AGR_ACC_XD_t newValue);
+mems_status_t LSM303AGR_ACC_R_XDouble(void *handle, LSM303AGR_ACC_XD_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_CFG
@@ -1398,8 +1398,8 @@ typedef enum {
 } LSM303AGR_ACC_YS_t;
 
 #define  	LSM303AGR_ACC_YS_MASK  	0x04
-status_t  LSM303AGR_ACC_W_YSingle(void *handle, LSM303AGR_ACC_YS_t newValue);
-status_t LSM303AGR_ACC_R_YSingle(void *handle, LSM303AGR_ACC_YS_t *value);
+mems_status_t  LSM303AGR_ACC_W_YSingle(void *handle, LSM303AGR_ACC_YS_t newValue);
+mems_status_t LSM303AGR_ACC_R_YSingle(void *handle, LSM303AGR_ACC_YS_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_CFG
@@ -1413,8 +1413,8 @@ typedef enum {
 } LSM303AGR_ACC_YD_t;
 
 #define  	LSM303AGR_ACC_YD_MASK  	0x08
-status_t  LSM303AGR_ACC_W_YDouble(void *handle, LSM303AGR_ACC_YD_t newValue);
-status_t LSM303AGR_ACC_R_YDouble(void *handle, LSM303AGR_ACC_YD_t *value);
+mems_status_t  LSM303AGR_ACC_W_YDouble(void *handle, LSM303AGR_ACC_YD_t newValue);
+mems_status_t LSM303AGR_ACC_R_YDouble(void *handle, LSM303AGR_ACC_YD_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_CFG
@@ -1428,8 +1428,8 @@ typedef enum {
 } LSM303AGR_ACC_ZS_t;
 
 #define  	LSM303AGR_ACC_ZS_MASK  	0x10
-status_t  LSM303AGR_ACC_W_ZSingle(void *handle, LSM303AGR_ACC_ZS_t newValue);
-status_t LSM303AGR_ACC_R_ZSingle(void *handle, LSM303AGR_ACC_ZS_t *value);
+mems_status_t  LSM303AGR_ACC_W_ZSingle(void *handle, LSM303AGR_ACC_ZS_t newValue);
+mems_status_t LSM303AGR_ACC_R_ZSingle(void *handle, LSM303AGR_ACC_ZS_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_CFG
@@ -1443,8 +1443,8 @@ typedef enum {
 } LSM303AGR_ACC_ZD_t;
 
 #define  	LSM303AGR_ACC_ZD_MASK  	0x20
-status_t  LSM303AGR_ACC_W_ZDouble(void *handle, LSM303AGR_ACC_ZD_t newValue);
-status_t LSM303AGR_ACC_R_ZDouble(void *handle, LSM303AGR_ACC_ZD_t *value);
+mems_status_t  LSM303AGR_ACC_W_ZDouble(void *handle, LSM303AGR_ACC_ZD_t newValue);
+mems_status_t LSM303AGR_ACC_R_ZDouble(void *handle, LSM303AGR_ACC_ZD_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_SRC
@@ -1458,7 +1458,7 @@ typedef enum {
 } LSM303AGR_ACC_X_t;
 
 #define  	LSM303AGR_ACC_X_MASK  	0x01
-status_t LSM303AGR_ACC_R_ClickX(void *handle, LSM303AGR_ACC_X_t *value);
+mems_status_t LSM303AGR_ACC_R_ClickX(void *handle, LSM303AGR_ACC_X_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_SRC
@@ -1472,7 +1472,7 @@ typedef enum {
 } LSM303AGR_ACC_Y_t;
 
 #define  	LSM303AGR_ACC_Y_MASK  	0x02
-status_t LSM303AGR_ACC_R_ClickY(void *handle, LSM303AGR_ACC_Y_t *value);
+mems_status_t LSM303AGR_ACC_R_ClickY(void *handle, LSM303AGR_ACC_Y_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_SRC
@@ -1486,7 +1486,7 @@ typedef enum {
 } LSM303AGR_ACC_Z_t;
 
 #define  	LSM303AGR_ACC_Z_MASK  	0x04
-status_t LSM303AGR_ACC_R_ClickZ(void *handle, LSM303AGR_ACC_Z_t *value);
+mems_status_t LSM303AGR_ACC_R_ClickZ(void *handle, LSM303AGR_ACC_Z_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_SRC
@@ -1500,7 +1500,7 @@ typedef enum {
 } LSM303AGR_ACC_SIGN_t;
 
 #define  	LSM303AGR_ACC_SIGN_MASK  	0x08
-status_t LSM303AGR_ACC_R_ClickSign(void *handle, LSM303AGR_ACC_SIGN_t *value);
+mems_status_t LSM303AGR_ACC_R_ClickSign(void *handle, LSM303AGR_ACC_SIGN_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_SRC
@@ -1514,7 +1514,7 @@ typedef enum {
 } LSM303AGR_ACC_SCLICK_t;
 
 #define  	LSM303AGR_ACC_SCLICK_MASK  	0x10
-status_t LSM303AGR_ACC_R_SingleCLICK(void *handle, LSM303AGR_ACC_SCLICK_t *value);
+mems_status_t LSM303AGR_ACC_R_SingleCLICK(void *handle, LSM303AGR_ACC_SCLICK_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_SRC
@@ -1528,7 +1528,7 @@ typedef enum {
 } LSM303AGR_ACC_DCLICK_t;
 
 #define  	LSM303AGR_ACC_DCLICK_MASK  	0x20
-status_t LSM303AGR_ACC_R_DoubleCLICK(void *handle, LSM303AGR_ACC_DCLICK_t *value);
+mems_status_t LSM303AGR_ACC_R_DoubleCLICK(void *handle, LSM303AGR_ACC_DCLICK_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_SRC
@@ -1542,7 +1542,7 @@ typedef enum {
 } LSM303AGR_ACC_CLICK_IA_t;
 
 #define  	LSM303AGR_ACC_IA_MASK  	0x40
-status_t LSM303AGR_ACC_R_CLICK_IA(void *handle, LSM303AGR_ACC_CLICK_IA_t *value);
+mems_status_t LSM303AGR_ACC_R_CLICK_IA(void *handle, LSM303AGR_ACC_CLICK_IA_t *value);
 
 /*******************************************************************************
 * Register      : CLICK_THS
@@ -1552,8 +1552,8 @@ status_t LSM303AGR_ACC_R_CLICK_IA(void *handle, LSM303AGR_ACC_CLICK_IA_t *value)
 *******************************************************************************/
 #define  	LSM303AGR_ACC_THS_MASK  	0x7F
 #define  	LSM303AGR_ACC_THS_POSITION  	0
-status_t  LSM303AGR_ACC_W_ClickThreshold(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_ClickThreshold(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_ClickThreshold(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_ClickThreshold(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : TIME_LIMIT
@@ -1563,8 +1563,8 @@ status_t LSM303AGR_ACC_R_ClickThreshold(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_ACC_TLI_MASK  	0x7F
 #define  	LSM303AGR_ACC_TLI_POSITION  	0
-status_t  LSM303AGR_ACC_W_ClickTimeLimit(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_ClickTimeLimit(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_ClickTimeLimit(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_ClickTimeLimit(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : TIME_LATENCY
@@ -1574,8 +1574,8 @@ status_t LSM303AGR_ACC_R_ClickTimeLimit(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_ACC_TLA_MASK  	0xFF
 #define  	LSM303AGR_ACC_TLA_POSITION  	0
-status_t  LSM303AGR_ACC_W_ClickTimeLatency(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_ClickTimeLatency(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_ClickTimeLatency(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_ClickTimeLatency(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : TIME_WINDOW
@@ -1585,21 +1585,21 @@ status_t LSM303AGR_ACC_R_ClickTimeLatency(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_ACC_TW_MASK  	0xFF
 #define  	LSM303AGR_ACC_TW_POSITION  	0
-status_t  LSM303AGR_ACC_W_ClickTimeWindow(void *handle, u8_t newValue);
-status_t LSM303AGR_ACC_R_ClickTimeWindow(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_ACC_W_ClickTimeWindow(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_ACC_R_ClickTimeWindow(void *handle, u8_t *value);
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : Voltage_ADC
 * Permission    : RO 
 *******************************************************************************/
-status_t LSM303AGR_ACC_Get_Voltage_ADC(void *handle, u8_t *buff); 
+mems_status_t LSM303AGR_ACC_Get_Voltage_ADC(void *handle, u8_t *buff); 
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : Acceleration
 * Permission    : RO 
 *******************************************************************************/
-status_t LSM303AGR_ACC_Get_Raw_Acceleration(void *handle, u8_t *buff); 
-status_t LSM303AGR_ACC_Get_Acceleration(void *handle, int *buff);
+mems_status_t LSM303AGR_ACC_Get_Raw_Acceleration(void *handle, u8_t *buff); 
+mems_status_t LSM303AGR_ACC_Get_Acceleration(void *handle, int *buff);
 
 #ifdef __cplusplus
 }

--- a/src/LSM303AGR_MAG_driver.c
+++ b/src/LSM303AGR_MAG_driver.c
@@ -60,7 +60,7 @@ extern uint8_t LSM303AGR_MAG_IO_Read(void *handle, uint8_t ReadAddr, uint8_t *pB
 * Output			: Data REad
 * Return			: None
 *******************************************************************************/
-status_t LSM303AGR_MAG_ReadReg( void *handle, u8_t Reg, u8_t* Data ) 
+mems_status_t LSM303AGR_MAG_ReadReg( void *handle, u8_t Reg, u8_t* Data ) 
 {
   
   if (LSM303AGR_MAG_IO_Read(handle, Reg, Data, 1))
@@ -81,7 +81,7 @@ status_t LSM303AGR_MAG_ReadReg( void *handle, u8_t Reg, u8_t* Data )
 * Output			: None
 * Return			: None
 *******************************************************************************/
-status_t LSM303AGR_MAG_WriteReg( void *handle, u8_t Reg, u8_t Data ) 
+mems_status_t LSM303AGR_MAG_WriteReg( void *handle, u8_t Reg, u8_t Data ) 
 {
     
   if (LSM303AGR_MAG_IO_Write(handle, Reg, &Data, 1))
@@ -133,7 +133,7 @@ void LSM303AGR_MAG_SwapHighLowByte(u8_t *bufferToSwap, u8_t numberOfByte, u8_t d
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_OFF_X_L(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_MAG_W_OFF_X_L(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -160,7 +160,7 @@ status_t  LSM303AGR_MAG_W_OFF_X_L(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_OFF_X_L(void *handle, u8_t *value)
+mems_status_t LSM303AGR_MAG_R_OFF_X_L(void *handle, u8_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_OFFSET_X_REG_L, (u8_t *)value) )
     return MEMS_ERROR;
@@ -177,7 +177,7 @@ status_t LSM303AGR_MAG_R_OFF_X_L(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_OFF_X_H(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_MAG_W_OFF_X_H(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -204,7 +204,7 @@ status_t  LSM303AGR_MAG_W_OFF_X_H(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_OFF_X_H(void *handle, u8_t *value)
+mems_status_t LSM303AGR_MAG_R_OFF_X_H(void *handle, u8_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_OFFSET_X_REG_H, (u8_t *)value) )
     return MEMS_ERROR;
@@ -221,7 +221,7 @@ status_t LSM303AGR_MAG_R_OFF_X_H(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_OFF_Y_L(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_MAG_W_OFF_Y_L(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -248,7 +248,7 @@ status_t  LSM303AGR_MAG_W_OFF_Y_L(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_OFF_Y_L(void *handle, u8_t *value)
+mems_status_t LSM303AGR_MAG_R_OFF_Y_L(void *handle, u8_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_OFFSET_Y_REG_L, (u8_t *)value) )
     return MEMS_ERROR;
@@ -265,7 +265,7 @@ status_t LSM303AGR_MAG_R_OFF_Y_L(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_OFF_Y_H(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_MAG_W_OFF_Y_H(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -292,7 +292,7 @@ status_t  LSM303AGR_MAG_W_OFF_Y_H(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_OFF_Y_H(void *handle, u8_t *value)
+mems_status_t LSM303AGR_MAG_R_OFF_Y_H(void *handle, u8_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_OFFSET_Y_REG_H, (u8_t *)value) )
     return MEMS_ERROR;
@@ -309,7 +309,7 @@ status_t LSM303AGR_MAG_R_OFF_Y_H(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_OFF_Z_L(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_MAG_W_OFF_Z_L(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -336,7 +336,7 @@ status_t  LSM303AGR_MAG_W_OFF_Z_L(void *handle, u8_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_OFF_Z_L(void *handle, u8_t *value)
+mems_status_t LSM303AGR_MAG_R_OFF_Z_L(void *handle, u8_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_OFFSET_Z_REG_L, (u8_t *)value) )
     return MEMS_ERROR;
@@ -353,7 +353,7 @@ status_t LSM303AGR_MAG_R_OFF_Z_L(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_OFF_Z_H(void *handle, u8_t newValue)
+mems_status_t  LSM303AGR_MAG_W_OFF_Z_H(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -375,7 +375,7 @@ status_t  LSM303AGR_MAG_W_OFF_Z_H(void *handle, u8_t newValue)
 /*******************************************************************************
  * Set/Get the Magnetic offsets
 *******************************************************************************/
-status_t LSM303AGR_MAG_Get_MagOff(void *handle, u16_t *magx_off, u16_t *magy_off, u16_t *magz_off)
+mems_status_t LSM303AGR_MAG_Get_MagOff(void *handle, u16_t *magx_off, u16_t *magy_off, u16_t *magz_off)
 {
   u8_t reg_l, reg_h;
 
@@ -403,7 +403,7 @@ status_t LSM303AGR_MAG_Get_MagOff(void *handle, u16_t *magx_off, u16_t *magy_off
   return MEMS_SUCCESS;
 }
 
-status_t LSM303AGR_MAG_Set_MagOff(void *handle, u16_t magx_off, u16_t magy_off, u16_t magz_off)
+mems_status_t LSM303AGR_MAG_Set_MagOff(void *handle, u16_t magx_off, u16_t magy_off, u16_t magz_off)
 {
   /* write mag_x_off */
   //LSM303AGR_MAG_W_OFF_X_L(magx_off & 0xff);
@@ -434,7 +434,7 @@ status_t LSM303AGR_MAG_Set_MagOff(void *handle, u16_t magx_off, u16_t magy_off, 
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_OFF_Z_H(void *handle, u8_t *value)
+mems_status_t LSM303AGR_MAG_R_OFF_Z_H(void *handle, u8_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_OFFSET_Z_REG_H, (u8_t *)value) )
     return MEMS_ERROR;
@@ -452,7 +452,7 @@ status_t LSM303AGR_MAG_R_OFF_Z_H(void *handle, u8_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_WHO_AM_I(void *handle, u8_t *value)
+mems_status_t LSM303AGR_MAG_R_WHO_AM_I(void *handle, u8_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_WHO_AM_I_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -469,7 +469,7 @@ status_t LSM303AGR_MAG_R_WHO_AM_I(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_MD(void *handle, LSM303AGR_MAG_MD_t newValue)
+mems_status_t  LSM303AGR_MAG_W_MD(void *handle, LSM303AGR_MAG_MD_t newValue)
 {
   u8_t value;
 
@@ -493,7 +493,7 @@ status_t  LSM303AGR_MAG_W_MD(void *handle, LSM303AGR_MAG_MD_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_MD(void *handle, LSM303AGR_MAG_MD_t *value)
+mems_status_t LSM303AGR_MAG_R_MD(void *handle, LSM303AGR_MAG_MD_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_A, (u8_t *)value) )
     return MEMS_ERROR;
@@ -509,7 +509,7 @@ status_t LSM303AGR_MAG_R_MD(void *handle, LSM303AGR_MAG_MD_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_ODR(void *handle, LSM303AGR_MAG_ODR_t newValue)
+mems_status_t  LSM303AGR_MAG_W_ODR(void *handle, LSM303AGR_MAG_ODR_t newValue)
 {
   u8_t value;
 
@@ -533,7 +533,7 @@ status_t  LSM303AGR_MAG_W_ODR(void *handle, LSM303AGR_MAG_ODR_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_ODR(void *handle, LSM303AGR_MAG_ODR_t *value)
+mems_status_t LSM303AGR_MAG_R_ODR(void *handle, LSM303AGR_MAG_ODR_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_A, (u8_t *)value) )
     return MEMS_ERROR;
@@ -549,7 +549,7 @@ status_t LSM303AGR_MAG_R_ODR(void *handle, LSM303AGR_MAG_ODR_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_LP(void *handle, LSM303AGR_MAG_LP_t newValue)
+mems_status_t  LSM303AGR_MAG_W_LP(void *handle, LSM303AGR_MAG_LP_t newValue)
 {
   u8_t value;
 
@@ -573,7 +573,7 @@ status_t  LSM303AGR_MAG_W_LP(void *handle, LSM303AGR_MAG_LP_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_LP(void *handle, LSM303AGR_MAG_LP_t *value)
+mems_status_t LSM303AGR_MAG_R_LP(void *handle, LSM303AGR_MAG_LP_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_A, (u8_t *)value) )
     return MEMS_ERROR;
@@ -589,7 +589,7 @@ status_t LSM303AGR_MAG_R_LP(void *handle, LSM303AGR_MAG_LP_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t newValue)
+mems_status_t  LSM303AGR_MAG_W_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t newValue)
 {
   u8_t value;
 
@@ -613,7 +613,7 @@ status_t  LSM303AGR_MAG_W_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t newVal
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t *value)
+mems_status_t LSM303AGR_MAG_R_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_A, (u8_t *)value) )
     return MEMS_ERROR;
@@ -629,7 +629,7 @@ status_t LSM303AGR_MAG_R_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_LPF(void *handle, LSM303AGR_MAG_LPF_t newValue)
+mems_status_t  LSM303AGR_MAG_W_LPF(void *handle, LSM303AGR_MAG_LPF_t newValue)
 {
   u8_t value;
 
@@ -653,7 +653,7 @@ status_t  LSM303AGR_MAG_W_LPF(void *handle, LSM303AGR_MAG_LPF_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_LPF(void *handle, LSM303AGR_MAG_LPF_t *value)
+mems_status_t LSM303AGR_MAG_R_LPF(void *handle, LSM303AGR_MAG_LPF_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_B, (u8_t *)value) )
     return MEMS_ERROR;
@@ -669,7 +669,7 @@ status_t LSM303AGR_MAG_R_LPF(void *handle, LSM303AGR_MAG_LPF_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t newValue)
+mems_status_t  LSM303AGR_MAG_W_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t newValue)
 {
   u8_t value;
 
@@ -693,7 +693,7 @@ status_t  LSM303AGR_MAG_W_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t newVal
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t *value)
+mems_status_t LSM303AGR_MAG_R_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_B, (u8_t *)value) )
     return MEMS_ERROR;
@@ -709,7 +709,7 @@ status_t LSM303AGR_MAG_R_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t newValue)
+mems_status_t  LSM303AGR_MAG_W_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t newValue)
 {
   u8_t value;
 
@@ -733,7 +733,7 @@ status_t  LSM303AGR_MAG_W_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t newVal
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t *value)
+mems_status_t LSM303AGR_MAG_R_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_B, (u8_t *)value) )
     return MEMS_ERROR;
@@ -749,7 +749,7 @@ status_t LSM303AGR_MAG_R_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t newValue)
+mems_status_t  LSM303AGR_MAG_W_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t newValue)
 {
   u8_t value;
 
@@ -773,7 +773,7 @@ status_t  LSM303AGR_MAG_W_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATA
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t *value)
+mems_status_t LSM303AGR_MAG_R_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_B, (u8_t *)value) )
     return MEMS_ERROR;
@@ -789,7 +789,7 @@ status_t LSM303AGR_MAG_R_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAO
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t newValue)
+mems_status_t  LSM303AGR_MAG_W_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t newValue)
 {
   u8_t value;
 
@@ -813,7 +813,7 @@ status_t  LSM303AGR_MAG_W_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t newValue
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t *value)
+mems_status_t LSM303AGR_MAG_R_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_C, (u8_t *)value) )
     return MEMS_ERROR;
@@ -829,7 +829,7 @@ status_t LSM303AGR_MAG_R_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_ST(void *handle, LSM303AGR_MAG_ST_t newValue)
+mems_status_t  LSM303AGR_MAG_W_ST(void *handle, LSM303AGR_MAG_ST_t newValue)
 {
   u8_t value;
 
@@ -853,7 +853,7 @@ status_t  LSM303AGR_MAG_W_ST(void *handle, LSM303AGR_MAG_ST_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_ST(void *handle, LSM303AGR_MAG_ST_t *value)
+mems_status_t LSM303AGR_MAG_R_ST(void *handle, LSM303AGR_MAG_ST_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_C, (u8_t *)value) )
     return MEMS_ERROR;
@@ -869,7 +869,7 @@ status_t LSM303AGR_MAG_R_ST(void *handle, LSM303AGR_MAG_ST_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_BLE(void *handle, LSM303AGR_MAG_BLE_t newValue)
+mems_status_t  LSM303AGR_MAG_W_BLE(void *handle, LSM303AGR_MAG_BLE_t newValue)
 {
   u8_t value;
 
@@ -893,7 +893,7 @@ status_t  LSM303AGR_MAG_W_BLE(void *handle, LSM303AGR_MAG_BLE_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_BLE(void *handle, LSM303AGR_MAG_BLE_t *value)
+mems_status_t LSM303AGR_MAG_R_BLE(void *handle, LSM303AGR_MAG_BLE_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_C, (u8_t *)value) )
     return MEMS_ERROR;
@@ -909,7 +909,7 @@ status_t LSM303AGR_MAG_R_BLE(void *handle, LSM303AGR_MAG_BLE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_BDU(void *handle, LSM303AGR_MAG_BDU_t newValue)
+mems_status_t  LSM303AGR_MAG_W_BDU(void *handle, LSM303AGR_MAG_BDU_t newValue)
 {
   u8_t value;
 
@@ -933,7 +933,7 @@ status_t  LSM303AGR_MAG_W_BDU(void *handle, LSM303AGR_MAG_BDU_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_BDU(void *handle, LSM303AGR_MAG_BDU_t *value)
+mems_status_t LSM303AGR_MAG_R_BDU(void *handle, LSM303AGR_MAG_BDU_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_C, (u8_t *)value) )
     return MEMS_ERROR;
@@ -949,7 +949,7 @@ status_t LSM303AGR_MAG_R_BDU(void *handle, LSM303AGR_MAG_BDU_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t newValue)
+mems_status_t  LSM303AGR_MAG_W_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t newValue)
 {
   u8_t value;
 
@@ -973,7 +973,7 @@ status_t  LSM303AGR_MAG_W_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t newValue
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t *value)
+mems_status_t LSM303AGR_MAG_R_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_C, (u8_t *)value) )
     return MEMS_ERROR;
@@ -989,7 +989,7 @@ status_t LSM303AGR_MAG_R_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t newValue)
+mems_status_t  LSM303AGR_MAG_W_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t newValue)
 {
   u8_t value;
 
@@ -1013,7 +1013,7 @@ status_t  LSM303AGR_MAG_W_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t 
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t *value)
+mems_status_t LSM303AGR_MAG_R_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_CFG_REG_C, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1029,7 +1029,7 @@ status_t LSM303AGR_MAG_R_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_IEN(void *handle, LSM303AGR_MAG_IEN_t newValue)
+mems_status_t  LSM303AGR_MAG_W_IEN(void *handle, LSM303AGR_MAG_IEN_t newValue)
 {
   u8_t value;
 
@@ -1053,7 +1053,7 @@ status_t  LSM303AGR_MAG_W_IEN(void *handle, LSM303AGR_MAG_IEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_IEN(void *handle, LSM303AGR_MAG_IEN_t *value)
+mems_status_t LSM303AGR_MAG_R_IEN(void *handle, LSM303AGR_MAG_IEN_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1069,7 +1069,7 @@ status_t LSM303AGR_MAG_R_IEN(void *handle, LSM303AGR_MAG_IEN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_IEL(void *handle, LSM303AGR_MAG_IEL_t newValue)
+mems_status_t  LSM303AGR_MAG_W_IEL(void *handle, LSM303AGR_MAG_IEL_t newValue)
 {
   u8_t value;
 
@@ -1093,7 +1093,7 @@ status_t  LSM303AGR_MAG_W_IEL(void *handle, LSM303AGR_MAG_IEL_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_IEL(void *handle, LSM303AGR_MAG_IEL_t *value)
+mems_status_t LSM303AGR_MAG_R_IEL(void *handle, LSM303AGR_MAG_IEL_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1109,7 +1109,7 @@ status_t LSM303AGR_MAG_R_IEL(void *handle, LSM303AGR_MAG_IEL_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_IEA(void *handle, LSM303AGR_MAG_IEA_t newValue)
+mems_status_t  LSM303AGR_MAG_W_IEA(void *handle, LSM303AGR_MAG_IEA_t newValue)
 {
   u8_t value;
 
@@ -1133,7 +1133,7 @@ status_t  LSM303AGR_MAG_W_IEA(void *handle, LSM303AGR_MAG_IEA_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_IEA(void *handle, LSM303AGR_MAG_IEA_t *value)
+mems_status_t LSM303AGR_MAG_R_IEA(void *handle, LSM303AGR_MAG_IEA_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1149,7 +1149,7 @@ status_t LSM303AGR_MAG_R_IEA(void *handle, LSM303AGR_MAG_IEA_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t newValue)
+mems_status_t  LSM303AGR_MAG_W_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t newValue)
 {
   u8_t value;
 
@@ -1173,7 +1173,7 @@ status_t  LSM303AGR_MAG_W_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t *value)
+mems_status_t LSM303AGR_MAG_R_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1189,7 +1189,7 @@ status_t LSM303AGR_MAG_R_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_YIEN(void *handle, LSM303AGR_MAG_YIEN_t newValue)
+mems_status_t  LSM303AGR_MAG_W_YIEN(void *handle, LSM303AGR_MAG_YIEN_t newValue)
 {
   u8_t value;
 
@@ -1213,7 +1213,7 @@ status_t  LSM303AGR_MAG_W_YIEN(void *handle, LSM303AGR_MAG_YIEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_YIEN(void *handle, LSM303AGR_MAG_YIEN_t *value)
+mems_status_t LSM303AGR_MAG_R_YIEN(void *handle, LSM303AGR_MAG_YIEN_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1229,7 +1229,7 @@ status_t LSM303AGR_MAG_R_YIEN(void *handle, LSM303AGR_MAG_YIEN_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM303AGR_MAG_W_XIEN(void *handle, LSM303AGR_MAG_XIEN_t newValue)
+mems_status_t  LSM303AGR_MAG_W_XIEN(void *handle, LSM303AGR_MAG_XIEN_t newValue)
 {
   u8_t value;
 
@@ -1253,7 +1253,7 @@ status_t  LSM303AGR_MAG_W_XIEN(void *handle, LSM303AGR_MAG_XIEN_t newValue)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_XIEN(void *handle, LSM303AGR_MAG_XIEN_t *value)
+mems_status_t LSM303AGR_MAG_R_XIEN(void *handle, LSM303AGR_MAG_XIEN_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_CTRL_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1270,7 +1270,7 @@ status_t LSM303AGR_MAG_R_XIEN(void *handle, LSM303AGR_MAG_XIEN_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_INT(void *handle, LSM303AGR_MAG_INT_t *value)
+mems_status_t LSM303AGR_MAG_R_INT(void *handle, LSM303AGR_MAG_INT_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1287,7 +1287,7 @@ status_t LSM303AGR_MAG_R_INT(void *handle, LSM303AGR_MAG_INT_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_MROI(void *handle, LSM303AGR_MAG_MROI_t *value)
+mems_status_t LSM303AGR_MAG_R_MROI(void *handle, LSM303AGR_MAG_MROI_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1304,7 +1304,7 @@ status_t LSM303AGR_MAG_R_MROI(void *handle, LSM303AGR_MAG_MROI_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_N_TH_S_Z(void *handle, LSM303AGR_MAG_N_TH_S_Z_t *value)
+mems_status_t LSM303AGR_MAG_R_N_TH_S_Z(void *handle, LSM303AGR_MAG_N_TH_S_Z_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1321,7 +1321,7 @@ status_t LSM303AGR_MAG_R_N_TH_S_Z(void *handle, LSM303AGR_MAG_N_TH_S_Z_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_N_TH_S_Y(void *handle, LSM303AGR_MAG_N_TH_S_Y_t *value)
+mems_status_t LSM303AGR_MAG_R_N_TH_S_Y(void *handle, LSM303AGR_MAG_N_TH_S_Y_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1338,7 +1338,7 @@ status_t LSM303AGR_MAG_R_N_TH_S_Y(void *handle, LSM303AGR_MAG_N_TH_S_Y_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_N_TH_S_X(void *handle, LSM303AGR_MAG_N_TH_S_X_t *value)
+mems_status_t LSM303AGR_MAG_R_N_TH_S_X(void *handle, LSM303AGR_MAG_N_TH_S_X_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1355,7 +1355,7 @@ status_t LSM303AGR_MAG_R_N_TH_S_X(void *handle, LSM303AGR_MAG_N_TH_S_X_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_P_TH_S_Z(void *handle, LSM303AGR_MAG_P_TH_S_Z_t *value)
+mems_status_t LSM303AGR_MAG_R_P_TH_S_Z(void *handle, LSM303AGR_MAG_P_TH_S_Z_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1372,7 +1372,7 @@ status_t LSM303AGR_MAG_R_P_TH_S_Z(void *handle, LSM303AGR_MAG_P_TH_S_Z_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_P_TH_S_Y(void *handle, LSM303AGR_MAG_P_TH_S_Y_t *value)
+mems_status_t LSM303AGR_MAG_R_P_TH_S_Y(void *handle, LSM303AGR_MAG_P_TH_S_Y_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1389,7 +1389,7 @@ status_t LSM303AGR_MAG_R_P_TH_S_Y(void *handle, LSM303AGR_MAG_P_TH_S_Y_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_P_TH_S_X(void *handle, LSM303AGR_MAG_P_TH_S_X_t *value)
+mems_status_t LSM303AGR_MAG_R_P_TH_S_X(void *handle, LSM303AGR_MAG_P_TH_S_X_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_INT_SOURCE_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1407,7 +1407,7 @@ status_t LSM303AGR_MAG_R_P_TH_S_X(void *handle, LSM303AGR_MAG_P_TH_S_X_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_XDA(void *handle, LSM303AGR_MAG_XDA_t *value)
+mems_status_t LSM303AGR_MAG_R_XDA(void *handle, LSM303AGR_MAG_XDA_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1424,7 +1424,7 @@ status_t LSM303AGR_MAG_R_XDA(void *handle, LSM303AGR_MAG_XDA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_YDA(void *handle, LSM303AGR_MAG_YDA_t *value)
+mems_status_t LSM303AGR_MAG_R_YDA(void *handle, LSM303AGR_MAG_YDA_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1441,7 +1441,7 @@ status_t LSM303AGR_MAG_R_YDA(void *handle, LSM303AGR_MAG_YDA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_ZDA(void *handle, LSM303AGR_MAG_ZDA_t *value)
+mems_status_t LSM303AGR_MAG_R_ZDA(void *handle, LSM303AGR_MAG_ZDA_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1458,7 +1458,7 @@ status_t LSM303AGR_MAG_R_ZDA(void *handle, LSM303AGR_MAG_ZDA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_ZYXDA(void *handle, LSM303AGR_MAG_ZYXDA_t *value)
+mems_status_t LSM303AGR_MAG_R_ZYXDA(void *handle, LSM303AGR_MAG_ZYXDA_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1475,7 +1475,7 @@ status_t LSM303AGR_MAG_R_ZYXDA(void *handle, LSM303AGR_MAG_ZYXDA_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_XOR(void *handle, LSM303AGR_MAG_XOR_t *value)
+mems_status_t LSM303AGR_MAG_R_XOR(void *handle, LSM303AGR_MAG_XOR_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1492,7 +1492,7 @@ status_t LSM303AGR_MAG_R_XOR(void *handle, LSM303AGR_MAG_XOR_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_YOR(void *handle, LSM303AGR_MAG_YOR_t *value)
+mems_status_t LSM303AGR_MAG_R_YOR(void *handle, LSM303AGR_MAG_YOR_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1509,7 +1509,7 @@ status_t LSM303AGR_MAG_R_YOR(void *handle, LSM303AGR_MAG_YOR_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_ZOR(void *handle, LSM303AGR_MAG_ZOR_t *value)
+mems_status_t LSM303AGR_MAG_R_ZOR(void *handle, LSM303AGR_MAG_ZOR_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1526,7 +1526,7 @@ status_t LSM303AGR_MAG_R_ZOR(void *handle, LSM303AGR_MAG_ZOR_t *value)
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM303AGR_MAG_R_ZYXOR(void *handle, LSM303AGR_MAG_ZYXOR_t *value)
+mems_status_t LSM303AGR_MAG_R_ZYXOR(void *handle, LSM303AGR_MAG_ZYXOR_t *value)
 {
  if( !LSM303AGR_MAG_ReadReg(handle, LSM303AGR_MAG_STATUS_REG, (u8_t *)value) )
     return MEMS_ERROR;
@@ -1536,13 +1536,13 @@ status_t LSM303AGR_MAG_R_ZYXOR(void *handle, LSM303AGR_MAG_ZYXOR_t *value)
   return MEMS_SUCCESS;
 }
 /*******************************************************************************
-* Function Name  : status_t LSM303AGR_MAG_Get_Raw_Magnetic(u8_t *buff)
+* Function Name  : mems_status_t LSM303AGR_MAG_Get_Raw_Magnetic(u8_t *buff)
 * Description    : Read Magnetic output register
 * Input          : pointer to [u8_t]
 * Output         : Magnetic buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM303AGR_MAG_Get_Raw_Magnetic(void *handle, u8_t *buff) 
+mems_status_t LSM303AGR_MAG_Get_Raw_Magnetic(void *handle, u8_t *buff) 
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -1565,7 +1565,7 @@ status_t LSM303AGR_MAG_Get_Raw_Magnetic(void *handle, u8_t *buff)
 
 #define LSM303AGR_MAG_SENSITIVITY	15/10
 
-status_t LSM303AGR_MAG_Get_Magnetic(void *handle, int *buff)
+mems_status_t LSM303AGR_MAG_Get_Magnetic(void *handle, int *buff)
 {
   Type3Axis16bit_U raw_data_tmp;
 
@@ -1583,13 +1583,13 @@ status_t LSM303AGR_MAG_Get_Magnetic(void *handle, int *buff)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM303AGR_MAG_Get_IntThreshld(u8_t *buff)
+* Function Name  : mems_status_t LSM303AGR_MAG_Get_IntThreshld(u8_t *buff)
 * Description    : Read IntThreshld output register
 * Input          : pointer to [u8_t]
 * Output         : IntThreshld buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM303AGR_MAG_Get_IntThreshld(void *handle, u8_t *buff) 
+mems_status_t LSM303AGR_MAG_Get_IntThreshld(void *handle, u8_t *buff) 
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -1611,13 +1611,13 @@ status_t LSM303AGR_MAG_Get_IntThreshld(void *handle, u8_t *buff)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM303AGR_MAG_Set_IntThreshld(u8_t *buff)
+* Function Name  : mems_status_t LSM303AGR_MAG_Set_IntThreshld(u8_t *buff)
 * Description    : Write IntThreshld output register
 * Input          : pointer to [u8_t]
 * Output         : IntThreshld buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM303AGR_MAG_Set_IntThreshld(void *handle, u8_t *buff) 
+mems_status_t LSM303AGR_MAG_Set_IntThreshld(void *handle, u8_t *buff) 
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;

--- a/src/LSM303AGR_MAG_driver.h
+++ b/src/LSM303AGR_MAG_driver.h
@@ -85,7 +85,7 @@ typedef union{
 typedef enum {
   MEMS_SUCCESS = 0x01,
   MEMS_ERROR   = 0x00	
-} status_t;
+} mems_status_t;
 
 #endif /*__SHARED__TYPES*/
 
@@ -107,8 +107,8 @@ void LSM303AGR_MAG_SwapHighLowByte(u8_t *bufferToSwap, u8_t numberOfByte, u8_t d
 
 /* Public Function Prototypes -------------------------------------------------------*/
 
-status_t LSM303AGR_MAG_ReadReg( void *handle, u8_t Reg, u8_t* Data );
-status_t LSM303AGR_MAG_WriteReg( void *handle, u8_t Reg, u8_t Data ); 
+mems_status_t LSM303AGR_MAG_ReadReg( void *handle, u8_t Reg, u8_t* Data );
+mems_status_t LSM303AGR_MAG_WriteReg( void *handle, u8_t Reg, u8_t Data ); 
 
 
 /************** Device Register  *******************/
@@ -142,8 +142,8 @@ status_t LSM303AGR_MAG_WriteReg( void *handle, u8_t Reg, u8_t Data );
 *******************************************************************************/
 #define  	LSM303AGR_MAG_OFF_X_L_MASK  	0xFF
 #define  	LSM303AGR_MAG_OFF_X_L_POSITION  	0
-status_t  LSM303AGR_MAG_W_OFF_X_L(void *handle, u8_t newValue);
-status_t LSM303AGR_MAG_R_OFF_X_L(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_MAG_W_OFF_X_L(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_MAG_R_OFF_X_L(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : OFFSET_X_REG_H
@@ -153,8 +153,8 @@ status_t LSM303AGR_MAG_R_OFF_X_L(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_MAG_OFF_X_H_MASK  	0xFF
 #define  	LSM303AGR_MAG_OFF_X_H_POSITION  	0
-status_t  LSM303AGR_MAG_W_OFF_X_H(void *handle, u8_t newValue);
-status_t LSM303AGR_MAG_R_OFF_X_H(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_MAG_W_OFF_X_H(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_MAG_R_OFF_X_H(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : OFFSET_Y_REG_L
@@ -164,8 +164,8 @@ status_t LSM303AGR_MAG_R_OFF_X_H(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_MAG_OFF_Y_L_MASK  	0xFF
 #define  	LSM303AGR_MAG_OFF_Y_L_POSITION  	0
-status_t  LSM303AGR_MAG_W_OFF_Y_L(void *handle, u8_t newValue);
-status_t LSM303AGR_MAG_R_OFF_Y_L(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_MAG_W_OFF_Y_L(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_MAG_R_OFF_Y_L(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : OFFSET_Y_REG_H
@@ -175,8 +175,8 @@ status_t LSM303AGR_MAG_R_OFF_Y_L(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_MAG_OFF_Y_H_MASK  	0xFF
 #define  	LSM303AGR_MAG_OFF_Y_H_POSITION  	0
-status_t  LSM303AGR_MAG_W_OFF_Y_H(void *handle, u8_t newValue);
-status_t LSM303AGR_MAG_R_OFF_Y_H(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_MAG_W_OFF_Y_H(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_MAG_R_OFF_Y_H(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : OFFSET_Z_REG_L
@@ -186,8 +186,8 @@ status_t LSM303AGR_MAG_R_OFF_Y_H(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_MAG_OFF_Z_L_MASK  	0xFF
 #define  	LSM303AGR_MAG_OFF_Z_L_POSITION  	0
-status_t  LSM303AGR_MAG_W_OFF_Z_L(void *handle, u8_t newValue);
-status_t LSM303AGR_MAG_R_OFF_Z_L(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_MAG_W_OFF_Z_L(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_MAG_R_OFF_Z_L(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : OFFSET_Z_REG_H
@@ -197,14 +197,14 @@ status_t LSM303AGR_MAG_R_OFF_Z_L(void *handle, u8_t *value);
 *******************************************************************************/
 #define  	LSM303AGR_MAG_OFF_Z_H_MASK  	0xFF
 #define  	LSM303AGR_MAG_OFF_Z_H_POSITION  	0
-status_t  LSM303AGR_MAG_W_OFF_Z_H(void *handle, u8_t newValue);
-status_t LSM303AGR_MAG_R_OFF_Z_H(void *handle, u8_t *value);
+mems_status_t  LSM303AGR_MAG_W_OFF_Z_H(void *handle, u8_t newValue);
+mems_status_t LSM303AGR_MAG_R_OFF_Z_H(void *handle, u8_t *value);
 
 /*******************************************************************************
  * Set/Get the Magnetic offsets
 *******************************************************************************/
-status_t LSM303AGR_MAG_Get_MagOff(void *handle, u16_t *magx_off, u16_t *magy_off, u16_t *magz_off);
-status_t LSM303AGR_MAG_Set_MagOff(void *handle, u16_t magx_off, u16_t magy_off, u16_t magz_off);
+mems_status_t LSM303AGR_MAG_Get_MagOff(void *handle, u16_t *magx_off, u16_t *magy_off, u16_t *magz_off);
+mems_status_t LSM303AGR_MAG_Set_MagOff(void *handle, u16_t magx_off, u16_t magy_off, u16_t magz_off);
 
 /*******************************************************************************
 * Register      : WHO_AM_I_REG
@@ -214,7 +214,7 @@ status_t LSM303AGR_MAG_Set_MagOff(void *handle, u16_t magx_off, u16_t magy_off, 
 *******************************************************************************/
 #define  	LSM303AGR_MAG_WHO_AM_I_MASK  	0xFF
 #define  	LSM303AGR_MAG_WHO_AM_I_POSITION  	0
-status_t LSM303AGR_MAG_R_WHO_AM_I(void *handle, u8_t *value);
+mems_status_t LSM303AGR_MAG_R_WHO_AM_I(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_A
@@ -230,8 +230,8 @@ typedef enum {
 } LSM303AGR_MAG_MD_t;
 
 #define  	LSM303AGR_MAG_MD_MASK  	0x03
-status_t  LSM303AGR_MAG_W_MD(void *handle, LSM303AGR_MAG_MD_t newValue);
-status_t LSM303AGR_MAG_R_MD(void *handle, LSM303AGR_MAG_MD_t *value);
+mems_status_t  LSM303AGR_MAG_W_MD(void *handle, LSM303AGR_MAG_MD_t newValue);
+mems_status_t LSM303AGR_MAG_R_MD(void *handle, LSM303AGR_MAG_MD_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_A
@@ -247,8 +247,8 @@ typedef enum {
 } LSM303AGR_MAG_ODR_t;
 
 #define  	LSM303AGR_MAG_ODR_MASK  	0x0C
-status_t  LSM303AGR_MAG_W_ODR(void *handle, LSM303AGR_MAG_ODR_t newValue);
-status_t LSM303AGR_MAG_R_ODR(void *handle, LSM303AGR_MAG_ODR_t *value);
+mems_status_t  LSM303AGR_MAG_W_ODR(void *handle, LSM303AGR_MAG_ODR_t newValue);
+mems_status_t LSM303AGR_MAG_R_ODR(void *handle, LSM303AGR_MAG_ODR_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_A
@@ -262,8 +262,8 @@ typedef enum {
 } LSM303AGR_MAG_LP_t;
 
 #define  	LSM303AGR_MAG_LP_MASK  	0x10
-status_t  LSM303AGR_MAG_W_LP(void *handle, LSM303AGR_MAG_LP_t newValue);
-status_t LSM303AGR_MAG_R_LP(void *handle, LSM303AGR_MAG_LP_t *value);
+mems_status_t  LSM303AGR_MAG_W_LP(void *handle, LSM303AGR_MAG_LP_t newValue);
+mems_status_t LSM303AGR_MAG_R_LP(void *handle, LSM303AGR_MAG_LP_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_A
@@ -277,8 +277,8 @@ typedef enum {
 } LSM303AGR_MAG_SOFT_RST_t;
 
 #define  	LSM303AGR_MAG_SOFT_RST_MASK  	0x20
-status_t  LSM303AGR_MAG_W_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t newValue);
-status_t LSM303AGR_MAG_R_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t *value);
+mems_status_t  LSM303AGR_MAG_W_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t newValue);
+mems_status_t LSM303AGR_MAG_R_SOFT_RST(void *handle, LSM303AGR_MAG_SOFT_RST_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_B
@@ -292,8 +292,8 @@ typedef enum {
 } LSM303AGR_MAG_LPF_t;
 
 #define  	LSM303AGR_MAG_LPF_MASK  	0x01
-status_t  LSM303AGR_MAG_W_LPF(void *handle, LSM303AGR_MAG_LPF_t newValue);
-status_t LSM303AGR_MAG_R_LPF(void *handle, LSM303AGR_MAG_LPF_t *value);
+mems_status_t  LSM303AGR_MAG_W_LPF(void *handle, LSM303AGR_MAG_LPF_t newValue);
+mems_status_t LSM303AGR_MAG_R_LPF(void *handle, LSM303AGR_MAG_LPF_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_B
@@ -307,8 +307,8 @@ typedef enum {
 } LSM303AGR_MAG_OFF_CANC_t;
 
 #define  	LSM303AGR_MAG_OFF_CANC_MASK  	0x02
-status_t  LSM303AGR_MAG_W_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t newValue);
-status_t LSM303AGR_MAG_R_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t *value);
+mems_status_t  LSM303AGR_MAG_W_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t newValue);
+mems_status_t LSM303AGR_MAG_R_OFF_CANC(void *handle, LSM303AGR_MAG_OFF_CANC_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_B
@@ -322,8 +322,8 @@ typedef enum {
 } LSM303AGR_MAG_SET_FREQ_t;
 
 #define  	LSM303AGR_MAG_SET_FREQ_MASK  	0x04
-status_t  LSM303AGR_MAG_W_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t newValue);
-status_t LSM303AGR_MAG_R_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t *value);
+mems_status_t  LSM303AGR_MAG_W_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t newValue);
+mems_status_t LSM303AGR_MAG_R_SET_FREQ(void *handle, LSM303AGR_MAG_SET_FREQ_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_B
@@ -337,8 +337,8 @@ typedef enum {
 } LSM303AGR_MAG_INT_ON_DATAOFF_t;
 
 #define  	LSM303AGR_MAG_INT_ON_DATAOFF_MASK  	0x08
-status_t  LSM303AGR_MAG_W_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t newValue);
-status_t LSM303AGR_MAG_R_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t *value);
+mems_status_t  LSM303AGR_MAG_W_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t newValue);
+mems_status_t LSM303AGR_MAG_R_INT_ON_DATAOFF(void *handle, LSM303AGR_MAG_INT_ON_DATAOFF_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_C
@@ -352,8 +352,8 @@ typedef enum {
 } LSM303AGR_MAG_INT_MAG_t;
 
 #define  	LSM303AGR_MAG_INT_MAG_MASK  	0x01
-status_t  LSM303AGR_MAG_W_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t newValue);
-status_t LSM303AGR_MAG_R_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t *value);
+mems_status_t  LSM303AGR_MAG_W_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t newValue);
+mems_status_t LSM303AGR_MAG_R_INT_MAG(void *handle, LSM303AGR_MAG_INT_MAG_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_C
@@ -367,8 +367,8 @@ typedef enum {
 } LSM303AGR_MAG_ST_t;
 
 #define  	LSM303AGR_MAG_ST_MASK  	0x02
-status_t  LSM303AGR_MAG_W_ST(void *handle, LSM303AGR_MAG_ST_t newValue);
-status_t LSM303AGR_MAG_R_ST(void *handle, LSM303AGR_MAG_ST_t *value);
+mems_status_t  LSM303AGR_MAG_W_ST(void *handle, LSM303AGR_MAG_ST_t newValue);
+mems_status_t LSM303AGR_MAG_R_ST(void *handle, LSM303AGR_MAG_ST_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_C
@@ -382,8 +382,8 @@ typedef enum {
 } LSM303AGR_MAG_BLE_t;
 
 #define  	LSM303AGR_MAG_BLE_MASK  	0x08
-status_t  LSM303AGR_MAG_W_BLE(void *handle, LSM303AGR_MAG_BLE_t newValue);
-status_t LSM303AGR_MAG_R_BLE(void *handle, LSM303AGR_MAG_BLE_t *value);
+mems_status_t  LSM303AGR_MAG_W_BLE(void *handle, LSM303AGR_MAG_BLE_t newValue);
+mems_status_t LSM303AGR_MAG_R_BLE(void *handle, LSM303AGR_MAG_BLE_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_C
@@ -397,8 +397,8 @@ typedef enum {
 } LSM303AGR_MAG_BDU_t;
 
 #define  	LSM303AGR_MAG_BDU_MASK  	0x10
-status_t  LSM303AGR_MAG_W_BDU(void *handle, LSM303AGR_MAG_BDU_t newValue);
-status_t LSM303AGR_MAG_R_BDU(void *handle, LSM303AGR_MAG_BDU_t *value);
+mems_status_t  LSM303AGR_MAG_W_BDU(void *handle, LSM303AGR_MAG_BDU_t newValue);
+mems_status_t LSM303AGR_MAG_R_BDU(void *handle, LSM303AGR_MAG_BDU_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_C
@@ -412,8 +412,8 @@ typedef enum {
 } LSM303AGR_MAG_I2C_DIS_t;
 
 #define  	LSM303AGR_MAG_I2C_DIS_MASK  	0x20
-status_t  LSM303AGR_MAG_W_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t newValue);
-status_t LSM303AGR_MAG_R_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t *value);
+mems_status_t  LSM303AGR_MAG_W_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t newValue);
+mems_status_t LSM303AGR_MAG_R_I2C_DIS(void *handle, LSM303AGR_MAG_I2C_DIS_t *value);
 
 /*******************************************************************************
 * Register      : CFG_REG_C
@@ -427,8 +427,8 @@ typedef enum {
 } LSM303AGR_MAG_INT_MAG_PIN_t;
 
 #define  	LSM303AGR_MAG_INT_MAG_PIN_MASK  	0x40
-status_t  LSM303AGR_MAG_W_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t newValue);
-status_t LSM303AGR_MAG_R_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t *value);
+mems_status_t  LSM303AGR_MAG_W_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t newValue);
+mems_status_t LSM303AGR_MAG_R_INT_MAG_PIN(void *handle, LSM303AGR_MAG_INT_MAG_PIN_t *value);
 
 /*******************************************************************************
 * Register      : INT_CTRL_REG
@@ -442,8 +442,8 @@ typedef enum {
 } LSM303AGR_MAG_IEN_t;
 
 #define  	LSM303AGR_MAG_IEN_MASK  	0x01
-status_t  LSM303AGR_MAG_W_IEN(void *handle, LSM303AGR_MAG_IEN_t newValue);
-status_t LSM303AGR_MAG_R_IEN(void *handle, LSM303AGR_MAG_IEN_t *value);
+mems_status_t  LSM303AGR_MAG_W_IEN(void *handle, LSM303AGR_MAG_IEN_t newValue);
+mems_status_t LSM303AGR_MAG_R_IEN(void *handle, LSM303AGR_MAG_IEN_t *value);
 
 /*******************************************************************************
 * Register      : INT_CTRL_REG
@@ -457,8 +457,8 @@ typedef enum {
 } LSM303AGR_MAG_IEL_t;
 
 #define  	LSM303AGR_MAG_IEL_MASK  	0x02
-status_t  LSM303AGR_MAG_W_IEL(void *handle, LSM303AGR_MAG_IEL_t newValue);
-status_t LSM303AGR_MAG_R_IEL(void *handle, LSM303AGR_MAG_IEL_t *value);
+mems_status_t  LSM303AGR_MAG_W_IEL(void *handle, LSM303AGR_MAG_IEL_t newValue);
+mems_status_t LSM303AGR_MAG_R_IEL(void *handle, LSM303AGR_MAG_IEL_t *value);
 
 /*******************************************************************************
 * Register      : INT_CTRL_REG
@@ -472,8 +472,8 @@ typedef enum {
 } LSM303AGR_MAG_IEA_t;
 
 #define  	LSM303AGR_MAG_IEA_MASK  	0x04
-status_t  LSM303AGR_MAG_W_IEA(void *handle, LSM303AGR_MAG_IEA_t newValue);
-status_t LSM303AGR_MAG_R_IEA(void *handle, LSM303AGR_MAG_IEA_t *value);
+mems_status_t  LSM303AGR_MAG_W_IEA(void *handle, LSM303AGR_MAG_IEA_t newValue);
+mems_status_t LSM303AGR_MAG_R_IEA(void *handle, LSM303AGR_MAG_IEA_t *value);
 
 /*******************************************************************************
 * Register      : INT_CTRL_REG
@@ -487,8 +487,8 @@ typedef enum {
 } LSM303AGR_MAG_ZIEN_t;
 
 #define  	LSM303AGR_MAG_ZIEN_MASK  	0x20
-status_t  LSM303AGR_MAG_W_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t newValue);
-status_t LSM303AGR_MAG_R_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t *value);
+mems_status_t  LSM303AGR_MAG_W_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t newValue);
+mems_status_t LSM303AGR_MAG_R_ZIEN(void *handle, LSM303AGR_MAG_ZIEN_t *value);
 
 /*******************************************************************************
 * Register      : INT_CTRL_REG
@@ -502,8 +502,8 @@ typedef enum {
 } LSM303AGR_MAG_YIEN_t;
 
 #define  	LSM303AGR_MAG_YIEN_MASK  	0x40
-status_t  LSM303AGR_MAG_W_YIEN(void *handle, LSM303AGR_MAG_YIEN_t newValue);
-status_t LSM303AGR_MAG_R_YIEN(void *handle, LSM303AGR_MAG_YIEN_t *value);
+mems_status_t  LSM303AGR_MAG_W_YIEN(void *handle, LSM303AGR_MAG_YIEN_t newValue);
+mems_status_t LSM303AGR_MAG_R_YIEN(void *handle, LSM303AGR_MAG_YIEN_t *value);
 
 /*******************************************************************************
 * Register      : INT_CTRL_REG
@@ -517,8 +517,8 @@ typedef enum {
 } LSM303AGR_MAG_XIEN_t;
 
 #define  	LSM303AGR_MAG_XIEN_MASK  	0x80
-status_t  LSM303AGR_MAG_W_XIEN(void *handle, LSM303AGR_MAG_XIEN_t newValue);
-status_t LSM303AGR_MAG_R_XIEN(void *handle, LSM303AGR_MAG_XIEN_t *value);
+mems_status_t  LSM303AGR_MAG_W_XIEN(void *handle, LSM303AGR_MAG_XIEN_t newValue);
+mems_status_t LSM303AGR_MAG_R_XIEN(void *handle, LSM303AGR_MAG_XIEN_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -532,7 +532,7 @@ typedef enum {
 } LSM303AGR_MAG_INT_t;
 
 #define  	LSM303AGR_MAG_INT_MASK  	0x01
-status_t LSM303AGR_MAG_R_INT(void *handle, LSM303AGR_MAG_INT_t *value);
+mems_status_t LSM303AGR_MAG_R_INT(void *handle, LSM303AGR_MAG_INT_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -546,7 +546,7 @@ typedef enum {
 } LSM303AGR_MAG_MROI_t;
 
 #define  	LSM303AGR_MAG_MROI_MASK  	0x02
-status_t LSM303AGR_MAG_R_MROI(void *handle, LSM303AGR_MAG_MROI_t *value);
+mems_status_t LSM303AGR_MAG_R_MROI(void *handle, LSM303AGR_MAG_MROI_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -560,7 +560,7 @@ typedef enum {
 } LSM303AGR_MAG_N_TH_S_Z_t;
 
 #define  	LSM303AGR_MAG_N_TH_S_Z_MASK  	0x04
-status_t LSM303AGR_MAG_R_N_TH_S_Z(void *handle, LSM303AGR_MAG_N_TH_S_Z_t *value);
+mems_status_t LSM303AGR_MAG_R_N_TH_S_Z(void *handle, LSM303AGR_MAG_N_TH_S_Z_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -574,7 +574,7 @@ typedef enum {
 } LSM303AGR_MAG_N_TH_S_Y_t;
 
 #define  	LSM303AGR_MAG_N_TH_S_Y_MASK  	0x08
-status_t LSM303AGR_MAG_R_N_TH_S_Y(void *handle, LSM303AGR_MAG_N_TH_S_Y_t *value);
+mems_status_t LSM303AGR_MAG_R_N_TH_S_Y(void *handle, LSM303AGR_MAG_N_TH_S_Y_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -588,7 +588,7 @@ typedef enum {
 } LSM303AGR_MAG_N_TH_S_X_t;
 
 #define  	LSM303AGR_MAG_N_TH_S_X_MASK  	0x10
-status_t LSM303AGR_MAG_R_N_TH_S_X(void *handle, LSM303AGR_MAG_N_TH_S_X_t *value);
+mems_status_t LSM303AGR_MAG_R_N_TH_S_X(void *handle, LSM303AGR_MAG_N_TH_S_X_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -602,7 +602,7 @@ typedef enum {
 } LSM303AGR_MAG_P_TH_S_Z_t;
 
 #define  	LSM303AGR_MAG_P_TH_S_Z_MASK  	0x20
-status_t LSM303AGR_MAG_R_P_TH_S_Z(void *handle, LSM303AGR_MAG_P_TH_S_Z_t *value);
+mems_status_t LSM303AGR_MAG_R_P_TH_S_Z(void *handle, LSM303AGR_MAG_P_TH_S_Z_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -616,7 +616,7 @@ typedef enum {
 } LSM303AGR_MAG_P_TH_S_Y_t;
 
 #define  	LSM303AGR_MAG_P_TH_S_Y_MASK  	0x40
-status_t LSM303AGR_MAG_R_P_TH_S_Y(void *handle, LSM303AGR_MAG_P_TH_S_Y_t *value);
+mems_status_t LSM303AGR_MAG_R_P_TH_S_Y(void *handle, LSM303AGR_MAG_P_TH_S_Y_t *value);
 
 /*******************************************************************************
 * Register      : INT_SOURCE_REG
@@ -630,7 +630,7 @@ typedef enum {
 } LSM303AGR_MAG_P_TH_S_X_t;
 
 #define  	LSM303AGR_MAG_P_TH_S_X_MASK  	0x80
-status_t LSM303AGR_MAG_R_P_TH_S_X(void *handle, LSM303AGR_MAG_P_TH_S_X_t *value);
+mems_status_t LSM303AGR_MAG_R_P_TH_S_X(void *handle, LSM303AGR_MAG_P_TH_S_X_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -644,7 +644,7 @@ typedef enum {
 } LSM303AGR_MAG_XDA_t;
 
 #define  	LSM303AGR_MAG_XDA_MASK  	0x01
-status_t LSM303AGR_MAG_R_XDA(void *handle, LSM303AGR_MAG_XDA_t *value);
+mems_status_t LSM303AGR_MAG_R_XDA(void *handle, LSM303AGR_MAG_XDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -658,7 +658,7 @@ typedef enum {
 } LSM303AGR_MAG_YDA_t;
 
 #define  	LSM303AGR_MAG_YDA_MASK  	0x02
-status_t LSM303AGR_MAG_R_YDA(void *handle, LSM303AGR_MAG_YDA_t *value);
+mems_status_t LSM303AGR_MAG_R_YDA(void *handle, LSM303AGR_MAG_YDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -672,7 +672,7 @@ typedef enum {
 } LSM303AGR_MAG_ZDA_t;
 
 #define  	LSM303AGR_MAG_ZDA_MASK  	0x04
-status_t LSM303AGR_MAG_R_ZDA(void *handle, LSM303AGR_MAG_ZDA_t *value);
+mems_status_t LSM303AGR_MAG_R_ZDA(void *handle, LSM303AGR_MAG_ZDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -686,7 +686,7 @@ typedef enum {
 } LSM303AGR_MAG_ZYXDA_t;
 
 #define  	LSM303AGR_MAG_ZYXDA_MASK  	0x08
-status_t LSM303AGR_MAG_R_ZYXDA(void *handle, LSM303AGR_MAG_ZYXDA_t *value);
+mems_status_t LSM303AGR_MAG_R_ZYXDA(void *handle, LSM303AGR_MAG_ZYXDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -700,7 +700,7 @@ typedef enum {
 } LSM303AGR_MAG_XOR_t;
 
 #define  	LSM303AGR_MAG_XOR_MASK  	0x10
-status_t LSM303AGR_MAG_R_XOR(void *handle, LSM303AGR_MAG_XOR_t *value);
+mems_status_t LSM303AGR_MAG_R_XOR(void *handle, LSM303AGR_MAG_XOR_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -714,7 +714,7 @@ typedef enum {
 } LSM303AGR_MAG_YOR_t;
 
 #define  	LSM303AGR_MAG_YOR_MASK  	0x20
-status_t LSM303AGR_MAG_R_YOR(void *handle, LSM303AGR_MAG_YOR_t *value);
+mems_status_t LSM303AGR_MAG_R_YOR(void *handle, LSM303AGR_MAG_YOR_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -728,7 +728,7 @@ typedef enum {
 } LSM303AGR_MAG_ZOR_t;
 
 #define  	LSM303AGR_MAG_ZOR_MASK  	0x40
-status_t LSM303AGR_MAG_R_ZOR(void *handle, LSM303AGR_MAG_ZOR_t *value);
+mems_status_t LSM303AGR_MAG_R_ZOR(void *handle, LSM303AGR_MAG_ZOR_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -742,22 +742,22 @@ typedef enum {
 } LSM303AGR_MAG_ZYXOR_t;
 
 #define  	LSM303AGR_MAG_ZYXOR_MASK  	0x80
-status_t LSM303AGR_MAG_R_ZYXOR(void *handle, LSM303AGR_MAG_ZYXOR_t *value);
+mems_status_t LSM303AGR_MAG_R_ZYXOR(void *handle, LSM303AGR_MAG_ZYXOR_t *value);
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : Magnetic
 * Permission    : ro 
 *******************************************************************************/
-status_t LSM303AGR_MAG_Get_Raw_Magnetic(void *handle, u8_t *buff);
-status_t LSM303AGR_MAG_Get_Magnetic(void *handle, int *buff);
+mems_status_t LSM303AGR_MAG_Get_Raw_Magnetic(void *handle, u8_t *buff);
+mems_status_t LSM303AGR_MAG_Get_Magnetic(void *handle, int *buff);
 
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : IntThreshld
 * Permission    : rw 
 *******************************************************************************/
-status_t LSM303AGR_MAG_Get_IntThreshld(void *handle, u8_t *buff); 
-status_t LSM303AGR_MAG_Set_IntThreshld(void *handle, u8_t *buff);
+mems_status_t LSM303AGR_MAG_Get_IntThreshld(void *handle, u8_t *buff); 
+mems_status_t LSM303AGR_MAG_Set_IntThreshld(void *handle, u8_t *buff);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi all,
I would like to apply this patch because "status_t" name is too generic and it can cause conflicts of multiple definitions with other X-NUCLEO libraries. The patch does not break any compatibility with high level APIs, so it should be safe.
Best Regards,
Carlo