### PR TITLE
Remove initialialization from constructor, move to Init() method.

### DIFF
--- a/examples/X_NUCLEO_IKS01A2_LSM303AGR_DataLog_Terminal/X_NUCLEO_IKS01A2_LSM303AGR_DataLog_Terminal.ino
+++ b/examples/X_NUCLEO_IKS01A2_LSM303AGR_DataLog_Terminal/X_NUCLEO_IKS01A2_LSM303AGR_DataLog_Terminal.ino
@@ -52,8 +52,8 @@
 #endif
 
 // Components.
-LSM303AGR_ACC_Sensor *Acc;
-LSM303AGR_MAG_Sensor *Mag;
+LSM303AGR_ACC_Sensor Acc(&DEV_I2C);
+LSM303AGR_MAG_Sensor Mag(&DEV_I2C);
 
 void setup() {
   // Led.
@@ -66,10 +66,10 @@ void setup() {
   DEV_I2C.begin();
 
   // Initlialize components.
-  Acc = new LSM303AGR_ACC_Sensor(&DEV_I2C);
-  Acc->Enable();
-  Mag = new LSM303AGR_MAG_Sensor(&DEV_I2C);
-  Mag->Enable();
+  Acc.Init();
+  Acc.Enable();
+  Mag.Init();
+  Mag.Enable();
 }
 
 void loop() {
@@ -81,11 +81,11 @@ void loop() {
 
   // Read accelerometer LSM303AGR.
   int32_t accelerometer[3];
-  Acc->GetAxes(accelerometer);
+  Acc.GetAxes(accelerometer);
   
   // Read magnetometer LSM303AGR.
   int32_t magnetometer[3];
-  Mag->GetAxes(magnetometer);
+  Mag.GetAxes(magnetometer);
 
   // Output data.
   SerialPort.print("| Acc[mg]: ");

--- a/src/LSM303AGR_ACC_Driver.h
+++ b/src/LSM303AGR_ACC_Driver.h
@@ -293,10 +293,10 @@ mems_status_t LSM303AGR_ACC_R_WHO_AM_I(void *handle, u8_t *value);
 *******************************************************************************/
 typedef enum {
   	LSM303AGR_ACC_TEMP_EN_DISABLED 		 =0x00,
-  	LSM303AGR_ACC_TEMP_EN_ENABLED 		 =0x40,
+  	LSM303AGR_ACC_TEMP_EN_ENABLED 		 =0xC0,
 } LSM303AGR_ACC_TEMP_EN_t;
 
-#define  	LSM303AGR_ACC_TEMP_EN_MASK  	0x40
+#define  	LSM303AGR_ACC_TEMP_EN_MASK  	0xC0
 mems_status_t  LSM303AGR_ACC_W_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t newValue);
 mems_status_t LSM303AGR_ACC_R_TEMP_EN_bits(void *handle, LSM303AGR_ACC_TEMP_EN_t *value);
 

--- a/src/LSM303AGR_ACC_Sensor.cpp
+++ b/src/LSM303AGR_ACC_Sensor.cpp
@@ -39,9 +39,8 @@
 /* Includes ------------------------------------------------------------------*/
 
 #include "Arduino.h"
-#include "Wire.h"
+#include "LSM303AGR_ACC_Driver.h"
 #include "LSM303AGR_ACC_Sensor.h"
-
 
 /* Class Implementation ------------------------------------------------------*/
 

--- a/src/LSM303AGR_ACC_Sensor.cpp
+++ b/src/LSM303AGR_ACC_Sensor.cpp
@@ -635,6 +635,52 @@ LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::DisableSelfTest(void)
     return LSM303AGR_ACC_STATUS_OK;
 }
 
+/**
+ * @brief Enable On-board Temperature Sensor
+ * @retval LSM303AGR_ACC_STATUS_OK in case of success
+ * @retval LSM303AGR_ACC_STATUS_ERROR in case of failure
+ */
+LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::EnableTemperatureSensor(void)
+{
+    if(LSM303AGR_ACC_W_TEMP_EN_bits((void*)this, LSM303AGR_ACC_TEMP_EN_ENABLED) == MEMS_ERROR)
+        return LSM303AGR_ACC_STATUS_ERROR;
+
+    return LSM303AGR_ACC_STATUS_OK;
+}
+
+/**
+ * @brief Disable On-board Temperature Sensor
+ * @retval LSM303AGR_ACC_STATUS_OK in case of success
+ * @retval LSM303AGR_ACC_STATUS_ERROR in case of failure
+ */
+LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::DisableTemperatureSensor(void)
+{
+    if (LSM303AGR_ACC_W_TEMP_EN_bits((void*)this, LSM303AGR_ACC_TEMP_EN_DISABLED) == MEMS_ERROR)
+        return LSM303AGR_ACC_STATUS_ERROR;
+
+    return LSM303AGR_ACC_STATUS_OK;
+}
+
+/**
+ * @brief Read the On-board Temperature Sensor
+ * @param temperature Pointer to a 16-bit value to read into
+ * @retval LSM303AGR_ACC_STATUS_OK in case of success
+ * @retval LSM303AGR_ACC_STATUS_ERROR in case of failure
+ */
+LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::GetTemperature(uint16_t* temperature)
+{
+    uint8_t* low = (uint8_t*) temperature;
+    uint8_t* high = low + 1;
+
+    if (LSM303AGR_ACC_ReadReg((void*)this, LSM303AGR_ACC_OUT_ADC3_L, low) == MEMS_ERROR)
+        return LSM303AGR_ACC_STATUS_ERROR;
+
+    if (LSM303AGR_ACC_ReadReg((void*)this, LSM303AGR_ACC_OUT_ADC3_H, high) == MEMS_ERROR)
+        return LSM303AGR_ACC_STATUS_ERROR;
+    
+    return LSM303AGR_ACC_STATUS_OK;
+}
+
 uint8_t LSM303AGR_ACC_IO_Write( void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite )
 {
   return ((LSM303AGR_ACC_Sensor *)handle)->IO_Write(pBuffer, WriteAddr, nBytesToWrite);

--- a/src/LSM303AGR_ACC_Sensor.cpp
+++ b/src/LSM303AGR_ACC_Sensor.cpp
@@ -600,6 +600,42 @@ LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::WriteReg( uint8_t reg, uint8_t
   return LSM303AGR_ACC_STATUS_OK;
 }
 
+/**
+ * @brief Enable LSM303 Embedded Self Test 
+ * @param self_test 0 for Self-Test 0, otherwise Self-Test 1
+ * @retval LSM303AGR_ACC_STATUS_OK in case of success
+ * @retval LSM303AGR_ACC_STATUS_ERROR in case of failure
+ */
+LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::EnableSelfTest(uint8_t self_test)
+{
+    // 4.2.4 Accelerometer self - test
+    // The self-test allows the user to check the sensor functionality without moving it.When the
+    // self-test is enabled, an actuation force is applied to the sensor, simulating a definite input
+    // acceleration.In this case the sensor outputs will exhibit a change in their DC levels which
+    // are related to the selected full scale through the device sensitivity.When the self-test is
+    // activated, the device output level is given by the algebraic sum of the signals produced by
+    // the acceleration acting on the sensor and by the electrostatic test-force.
+    
+    if (LSM303AGR_ACC_W_SelfTest(this, self_test == 0 ? LSM303AGR_ACC_ST_SELF_TEST_0 : LSM303AGR_ACC_ST_SELF_TEST_1) == MEMS_ERROR)    
+        return LSM303AGR_ACC_STATUS_ERROR;
+    
+
+    return LSM303AGR_ACC_STATUS_OK;
+}
+
+/**
+ * @brief Disable LSM303 Embedded Self Test
+ * @retval LSM303AGR_ACC_STATUS_OK in case of success
+ * @retval LSM303AGR_ACC_STATUS_ERROR in case of failure
+ */
+LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::DisableSelfTest(void)
+{    
+    if (LSM303AGR_ACC_W_SelfTest(this, LSM303AGR_ACC_ST_DISABLED))
+        return LSM303AGR_ACC_STATUS_ERROR;
+
+    return LSM303AGR_ACC_STATUS_OK;
+}
+
 uint8_t LSM303AGR_ACC_IO_Write( void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite )
 {
   return ((LSM303AGR_ACC_Sensor *)handle)->IO_Write(pBuffer, WriteAddr, nBytesToWrite);

--- a/src/LSM303AGR_ACC_Sensor.cpp
+++ b/src/LSM303AGR_ACC_Sensor.cpp
@@ -672,6 +672,10 @@ LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::GetTemperature(uint16_t* tempe
     uint8_t* low = (uint8_t*) temperature;
     uint8_t* high = low + 1;
 
+    LSM303AGR_ACC_1DA_t value;
+    if(LSM303AGR_ACC_R_x_data_avail((void*)this, &value) == MEMS_ERROR || value != LSM303AGR_ACC_1DA_AVAILABLE)
+        return LSM303AGR_ACC_STATUS_TIMEOUT;
+
     if (LSM303AGR_ACC_ReadReg((void*)this, LSM303AGR_ACC_OUT_ADC3_L, low) == MEMS_ERROR)
         return LSM303AGR_ACC_STATUS_ERROR;
 

--- a/src/LSM303AGR_ACC_Sensor.cpp
+++ b/src/LSM303AGR_ACC_Sensor.cpp
@@ -49,54 +49,9 @@
  * @param i2c object of an helper class which handles the I2C peripheral
  * @param address the address of the component's instance
  */
-LSM303AGR_ACC_Sensor::LSM303AGR_ACC_Sensor(TwoWire *i2c) : dev_i2c(i2c)
+LSM303AGR_ACC_Sensor::LSM303AGR_ACC_Sensor(TwoWire *i2c) : LSM303AGR_ACC_Sensor(i2c, LSM303AGR_ACC_I2C_ADDRESS)
 {
-  address = LSM303AGR_ACC_I2C_ADDRESS;
   
-  /* Enable BDU */
-  if ( LSM303AGR_ACC_W_BlockDataUpdate( (void *)this, LSM303AGR_ACC_BDU_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* FIFO mode selection */
-  if ( LSM303AGR_ACC_W_FifoMode( (void *)this, LSM303AGR_ACC_FM_BYPASS ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* Output data rate selection - power down. */
-  if ( LSM303AGR_ACC_W_ODR( (void *)this, LSM303AGR_ACC_ODR_DO_PWR_DOWN ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* Full scale selection. */
-  if ( SetFS( 2.0f ) == LSM303AGR_ACC_STATUS_ERROR )
-  {
-    return;
-  }
-  
-  /* Enable axes. */
-  if ( LSM303AGR_ACC_W_XEN( (void *)this, LSM303AGR_ACC_XEN_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  if ( LSM303AGR_ACC_W_YEN ( (void *)this, LSM303AGR_ACC_YEN_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  if ( LSM303AGR_ACC_W_ZEN ( (void *)this, LSM303AGR_ACC_ZEN_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* Select default output data rate. */
-  Last_ODR = 100.0f;
-  
-  isEnabled = 0;
 };
 
 /** Constructor
@@ -105,51 +60,57 @@ LSM303AGR_ACC_Sensor::LSM303AGR_ACC_Sensor(TwoWire *i2c) : dev_i2c(i2c)
  */
 LSM303AGR_ACC_Sensor::LSM303AGR_ACC_Sensor(TwoWire *i2c, uint8_t address) : dev_i2c(i2c), address(address)
 {
-  /* Enable BDU */
-  if ( LSM303AGR_ACC_W_BlockDataUpdate( (void *)this, LSM303AGR_ACC_BDU_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* FIFO mode selection */
-  if ( LSM303AGR_ACC_W_FifoMode( (void *)this, LSM303AGR_ACC_FM_BYPASS ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* Output data rate selection - power down. */
-  if ( LSM303AGR_ACC_W_ODR( (void *)this, LSM303AGR_ACC_ODR_DO_PWR_DOWN ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* Full scale selection. */
-  if ( SetFS( 2.0f ) == LSM303AGR_ACC_STATUS_ERROR )
-  {
-    return;
-  }
-  
-  /* Enable axes. */
-  if ( LSM303AGR_ACC_W_XEN( (void *)this, LSM303AGR_ACC_XEN_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  if ( LSM303AGR_ACC_W_YEN ( (void *)this, LSM303AGR_ACC_YEN_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  if ( LSM303AGR_ACC_W_ZEN ( (void *)this, LSM303AGR_ACC_ZEN_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  /* Select default output data rate. */
-  Last_ODR = 100.0f;
-  
-  isEnabled = 0;
-};
+    
+}
+
+void LSM303AGR_ACC_Sensor::Init()
+{
+    /* Enable BDU */
+    if (LSM303AGR_ACC_W_BlockDataUpdate((void*)this, LSM303AGR_ACC_BDU_ENABLED) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    /* FIFO mode selection */
+    if (LSM303AGR_ACC_W_FifoMode((void*)this, LSM303AGR_ACC_FM_BYPASS) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    /* Output data rate selection - power down. */
+    if (LSM303AGR_ACC_W_ODR((void*)this, LSM303AGR_ACC_ODR_DO_PWR_DOWN) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    /* Full scale selection. */
+    if (SetFS(2.0f) == LSM303AGR_ACC_STATUS_ERROR)
+    {
+        return;
+    }
+
+    /* Enable axes. */
+    if (LSM303AGR_ACC_W_XEN((void*)this, LSM303AGR_ACC_XEN_ENABLED) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    if (LSM303AGR_ACC_W_YEN((void*)this, LSM303AGR_ACC_YEN_ENABLED) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    if (LSM303AGR_ACC_W_ZEN((void*)this, LSM303AGR_ACC_ZEN_ENABLED) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    /* Select default output data rate. */
+    Last_ODR = 100.0f;
+
+    isEnabled = 0;
+}
+;
 
 /**
  * @brief  Enable LSM303AGR Accelerator

--- a/src/LSM303AGR_ACC_Sensor.cpp
+++ b/src/LSM303AGR_ACC_Sensor.cpp
@@ -63,52 +63,30 @@ LSM303AGR_ACC_Sensor::LSM303AGR_ACC_Sensor(TwoWire *i2c, uint8_t address) : dev_
     
 }
 
-void LSM303AGR_ACC_Sensor::Init()
+LSM303AGR_ACC_StatusTypeDef LSM303AGR_ACC_Sensor::Init()
 {
     /* Enable BDU */
-    if (LSM303AGR_ACC_W_BlockDataUpdate((void*)this, LSM303AGR_ACC_BDU_ENABLED) == MEMS_ERROR)
+    if (
+        LSM303AGR_ACC_W_BlockDataUpdate((void*)this, LSM303AGR_ACC_BDU_ENABLED) == MEMS_ERROR ||
+        /* FIFO mode selection */
+        LSM303AGR_ACC_W_FifoMode((void*)this, LSM303AGR_ACC_FM_BYPASS) == MEMS_ERROR ||
+        /* Output data rate selection - power down. */
+        LSM303AGR_ACC_W_ODR((void*)this, LSM303AGR_ACC_ODR_DO_PWR_DOWN) == MEMS_ERROR ||
+        /* Full scale selection. */
+        SetFS(2.0f) == LSM303AGR_ACC_STATUS_ERROR ||
+        /* Enable axes. */
+        LSM303AGR_ACC_W_XEN((void*)this, LSM303AGR_ACC_XEN_ENABLED) == MEMS_ERROR || 
+        LSM303AGR_ACC_W_YEN((void*)this, LSM303AGR_ACC_YEN_ENABLED) == MEMS_ERROR ||
+        LSM303AGR_ACC_W_ZEN((void*)this, LSM303AGR_ACC_ZEN_ENABLED) == MEMS_ERROR
+    )
     {
-        return;
-    }
-
-    /* FIFO mode selection */
-    if (LSM303AGR_ACC_W_FifoMode((void*)this, LSM303AGR_ACC_FM_BYPASS) == MEMS_ERROR)
-    {
-        return;
-    }
-
-    /* Output data rate selection - power down. */
-    if (LSM303AGR_ACC_W_ODR((void*)this, LSM303AGR_ACC_ODR_DO_PWR_DOWN) == MEMS_ERROR)
-    {
-        return;
-    }
-
-    /* Full scale selection. */
-    if (SetFS(2.0f) == LSM303AGR_ACC_STATUS_ERROR)
-    {
-        return;
-    }
-
-    /* Enable axes. */
-    if (LSM303AGR_ACC_W_XEN((void*)this, LSM303AGR_ACC_XEN_ENABLED) == MEMS_ERROR)
-    {
-        return;
-    }
-
-    if (LSM303AGR_ACC_W_YEN((void*)this, LSM303AGR_ACC_YEN_ENABLED) == MEMS_ERROR)
-    {
-        return;
-    }
-
-    if (LSM303AGR_ACC_W_ZEN((void*)this, LSM303AGR_ACC_ZEN_ENABLED) == MEMS_ERROR)
-    {
-        return;
+        return LSM303AGR_ACC_STATUS_ERROR;
     }
 
     /* Select default output data rate. */
     Last_ODR = 100.0f;
-
     isEnabled = 0;
+    return LSM303AGR_ACC_STATUS_OK;
 }
 ;
 

--- a/src/LSM303AGR_ACC_Sensor.h
+++ b/src/LSM303AGR_ACC_Sensor.h
@@ -83,6 +83,7 @@ class LSM303AGR_ACC_Sensor
   public:
     LSM303AGR_ACC_Sensor                       (TwoWire *i2c);
     LSM303AGR_ACC_Sensor                       (TwoWire *i2c, uint8_t address);
+    void Init                                  (void);
     LSM303AGR_ACC_StatusTypeDef Enable         (void);
     LSM303AGR_ACC_StatusTypeDef Disable        (void);
     LSM303AGR_ACC_StatusTypeDef ReadID         (uint8_t *p_id);

--- a/src/LSM303AGR_ACC_Sensor.h
+++ b/src/LSM303AGR_ACC_Sensor.h
@@ -97,6 +97,9 @@ class LSM303AGR_ACC_Sensor
 	LSM303AGR_ACC_StatusTypeDef ReadReg         (uint8_t reg, uint8_t *data);
 	LSM303AGR_ACC_StatusTypeDef WriteReg        (uint8_t reg, uint8_t data);
 
+    LSM303AGR_ACC_StatusTypeDef EnableSelfTest  (uint8_t self_test = 0);
+    LSM303AGR_ACC_StatusTypeDef DisableSelfTest (void);
+
 	/**
      * @brief Utility function to read data.
      * @param  pBuffer: pointer to data to be read.

--- a/src/LSM303AGR_ACC_Sensor.h
+++ b/src/LSM303AGR_ACC_Sensor.h
@@ -81,22 +81,22 @@ typedef enum
 class LSM303AGR_ACC_Sensor
 {
   public:
-    LSM303AGR_ACC_Sensor                       (TwoWire *i2c);
-    LSM303AGR_ACC_Sensor                       (TwoWire *i2c, uint8_t address);
-    void Init                                  (void);
-    LSM303AGR_ACC_StatusTypeDef Enable         (void);
-    LSM303AGR_ACC_StatusTypeDef Disable        (void);
-    LSM303AGR_ACC_StatusTypeDef ReadID         (uint8_t *p_id);
-    LSM303AGR_ACC_StatusTypeDef GetAxes        (int32_t *pData);
-    LSM303AGR_ACC_StatusTypeDef GetSensitivity (float *pfData);
-	LSM303AGR_ACC_StatusTypeDef GetAxesRaw     (int16_t *pData);
-	LSM303AGR_ACC_StatusTypeDef GetODR         (float *odr);
-	LSM303AGR_ACC_StatusTypeDef SetODR         (float odr);
-	LSM303AGR_ACC_StatusTypeDef GetFS          (float *fullScale);
-	LSM303AGR_ACC_StatusTypeDef SetFS          (float fullScale);
-	LSM303AGR_ACC_StatusTypeDef ReadReg        (uint8_t reg, uint8_t *data);
-	LSM303AGR_ACC_StatusTypeDef WriteReg       (uint8_t reg, uint8_t data);
-	
+    LSM303AGR_ACC_Sensor                        (TwoWire *i2c);
+    LSM303AGR_ACC_Sensor                        (TwoWire *i2c, uint8_t address);
+    LSM303AGR_ACC_StatusTypeDef Init                                   (void);
+    LSM303AGR_ACC_StatusTypeDef Enable          (void);
+    LSM303AGR_ACC_StatusTypeDef Disable         (void);
+    LSM303AGR_ACC_StatusTypeDef ReadID          (uint8_t *p_id);
+    LSM303AGR_ACC_StatusTypeDef GetAxes         (int32_t *pData);
+    LSM303AGR_ACC_StatusTypeDef GetSensitivity  (float *pfData);
+	LSM303AGR_ACC_StatusTypeDef GetAxesRaw      (int16_t *pData);
+	LSM303AGR_ACC_StatusTypeDef GetODR          (float *odr);
+	LSM303AGR_ACC_StatusTypeDef SetODR          (float odr);
+	LSM303AGR_ACC_StatusTypeDef GetFS           (float *fullScale);
+	LSM303AGR_ACC_StatusTypeDef SetFS           (float fullScale);
+	LSM303AGR_ACC_StatusTypeDef ReadReg         (uint8_t reg, uint8_t *data);
+	LSM303AGR_ACC_StatusTypeDef WriteReg        (uint8_t reg, uint8_t data);
+
 	/**
      * @brief Utility function to read data.
      * @param  pBuffer: pointer to data to be read.

--- a/src/LSM303AGR_ACC_Sensor.h
+++ b/src/LSM303AGR_ACC_Sensor.h
@@ -45,7 +45,7 @@
 /* Includes ------------------------------------------------------------------*/
 
 #include "Wire.h"
-#include "LSM303AGR_ACC_Driver.h"
+
 
 /* Defines -------------------------------------------------------------------*/
 #define LSM303AGR_ACC_SENSITIVITY_FOR_FS_2G_NORMAL_MODE               3.900f  /**< Sensitivity value for 2 g full scale and normal mode [mg/LSB] */

--- a/src/LSM303AGR_ACC_Sensor.h
+++ b/src/LSM303AGR_ACC_Sensor.h
@@ -87,18 +87,26 @@ class LSM303AGR_ACC_Sensor
     LSM303AGR_ACC_StatusTypeDef Enable          (void);
     LSM303AGR_ACC_StatusTypeDef Disable         (void);
     LSM303AGR_ACC_StatusTypeDef ReadID          (uint8_t *p_id);
+    
     LSM303AGR_ACC_StatusTypeDef GetAxes         (int32_t *pData);
     LSM303AGR_ACC_StatusTypeDef GetSensitivity  (float *pfData);
 	LSM303AGR_ACC_StatusTypeDef GetAxesRaw      (int16_t *pData);
-	LSM303AGR_ACC_StatusTypeDef GetODR          (float *odr);
+
+    LSM303AGR_ACC_StatusTypeDef GetODR          (float *odr);
 	LSM303AGR_ACC_StatusTypeDef SetODR          (float odr);
+
 	LSM303AGR_ACC_StatusTypeDef GetFS           (float *fullScale);
 	LSM303AGR_ACC_StatusTypeDef SetFS           (float fullScale);
+
 	LSM303AGR_ACC_StatusTypeDef ReadReg         (uint8_t reg, uint8_t *data);
 	LSM303AGR_ACC_StatusTypeDef WriteReg        (uint8_t reg, uint8_t data);
 
     LSM303AGR_ACC_StatusTypeDef EnableSelfTest  (uint8_t self_test = 0);
     LSM303AGR_ACC_StatusTypeDef DisableSelfTest (void);
+
+    LSM303AGR_ACC_StatusTypeDef EnableTemperatureSensor     (void);
+    LSM303AGR_ACC_StatusTypeDef DisableTemperatureSensor    (void);
+    LSM303AGR_ACC_StatusTypeDef GetTemperature              (uint16_t* temperature);
 
 	/**
      * @brief Utility function to read data.

--- a/src/LSM303AGR_MAG_Sensor.cpp
+++ b/src/LSM303AGR_MAG_Sensor.cpp
@@ -49,36 +49,9 @@
  * @param i2c object of an helper class which handles the I2C peripheral
  * @param address the address of the component's instance
  */
-LSM303AGR_MAG_Sensor::LSM303AGR_MAG_Sensor(TwoWire *i2c) : dev_i2c(i2c)
+LSM303AGR_MAG_Sensor::LSM303AGR_MAG_Sensor(TwoWire *i2c) : LSM303AGR_MAG_Sensor(i2c, LSM303AGR_MAG_I2C_ADDRESS)
 {
-  address = LSM303AGR_MAG_I2C_ADDRESS;
-
-  /* Operating mode selection - power down */
-  if ( LSM303AGR_MAG_W_MD( (void *)this, LSM303AGR_MAG_MD_IDLE1_MODE ) == MEMS_ERROR )
-  {
-    return;
-  }
   
-  /* Enable BDU */
-  if ( LSM303AGR_MAG_W_BDU( (void *)this, LSM303AGR_MAG_BDU_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  if ( SetODR( 100.0f ) == LSM303AGR_MAG_STATUS_ERROR )
-  {
-    return;
-  }
-  
-  if ( SetFS( 50.0f ) == LSM303AGR_MAG_STATUS_ERROR )
-  {
-    return;
-  }
-
-  if ( LSM303AGR_MAG_W_ST( (void *)this, LSM303AGR_MAG_ST_DISABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
 };
 
 /** Constructor
@@ -87,33 +60,39 @@ LSM303AGR_MAG_Sensor::LSM303AGR_MAG_Sensor(TwoWire *i2c) : dev_i2c(i2c)
  */
 LSM303AGR_MAG_Sensor::LSM303AGR_MAG_Sensor(TwoWire *i2c, uint8_t address) : dev_i2c(i2c), address(address)
 {
-  /* Operating mode selection - power down */
-  if ( LSM303AGR_MAG_W_MD( (void *)this, LSM303AGR_MAG_MD_IDLE1_MODE ) == MEMS_ERROR )
-  {
-    return;
-  }
   
-  /* Enable BDU */
-  if ( LSM303AGR_MAG_W_BDU( (void *)this, LSM303AGR_MAG_BDU_ENABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-  
-  if ( SetODR( 100.0f ) == LSM303AGR_MAG_STATUS_ERROR )
-  {
-    return;
-  }
-  
-  if ( SetFS( 50.0f ) == LSM303AGR_MAG_STATUS_ERROR )
-  {
-    return;
-  }
+}
 
-  if ( LSM303AGR_MAG_W_ST( (void *)this, LSM303AGR_MAG_ST_DISABLED ) == MEMS_ERROR )
-  {
-    return;
-  }
-};
+void LSM303AGR_MAG_Sensor::Init(void)
+{
+
+    /* Operating mode selection - power down */
+    if (LSM303AGR_MAG_W_MD((void*)this, LSM303AGR_MAG_MD_IDLE1_MODE) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    /* Enable BDU */
+    if (LSM303AGR_MAG_W_BDU((void*)this, LSM303AGR_MAG_BDU_ENABLED) == MEMS_ERROR)
+    {
+        return;
+    }
+
+    if (SetODR(100.0f) == LSM303AGR_MAG_STATUS_ERROR)
+    {
+        return;
+    }
+
+    if (SetFS(50.0f) == LSM303AGR_MAG_STATUS_ERROR)
+    {
+        return;
+    }
+
+    if (LSM303AGR_MAG_W_ST((void*)this, LSM303AGR_MAG_ST_DISABLED) == MEMS_ERROR)
+    {
+        return;
+    }
+}
 
 /**
  * @brief  Enable LSM303AGR magnetometer

--- a/src/LSM303AGR_MAG_Sensor.h
+++ b/src/LSM303AGR_MAG_Sensor.h
@@ -68,6 +68,7 @@ class LSM303AGR_MAG_Sensor
   public:
     LSM303AGR_MAG_Sensor                       (TwoWire *i2c);
     LSM303AGR_MAG_Sensor                       (TwoWire *i2c, uint8_t address);
+    void Init                                  (void);
     LSM303AGR_MAG_StatusTypeDef Enable         (void);
     LSM303AGR_MAG_StatusTypeDef Disable        (void);
     LSM303AGR_MAG_StatusTypeDef ReadID         (uint8_t *p_id);


### PR DESCRIPTION
Initialization of the device in the constructor creates hardfaults with static instances, and does not compile on targets with no heap (no new operator).
The overloaded constructor had duplicated code for cases with (TwoWire *i2c) and (TwoWire *i2c, uint8_t address). This has been replaced with a call to the classes' own constructor.

Update example as well.